### PR TITLE
Task 43 (flow.step flat rate Opt X) + Task 58 (12-item polish bundle) + Task 52.3 close

### DIFF
--- a/docs/pricing/businesslogic-api-pricing.md
+++ b/docs/pricing/businesslogic-api-pricing.md
@@ -113,6 +113,48 @@ Bought ad-hoc or auto-attached when limits are hit (only with auto-reload enable
 
 ---
 
+## 3b. flow.step Metering (non-AI steps)
+
+### Rate
+
+**€0.001 per non-AI flow step** (1 millicent/step).
+
+A "step" is a single node that successfully completes inside a flow execution (emitted as a `flow.step` usage event). The flat rate is applied by the usage-consumer aggregator during hourly rollup into `monthly_aggregates.total_cost_eur`.
+
+### AI step exclusion
+
+Steps running AI-node types are **not charged** as flow steps — they are already debited from the AI Wallet via `ai.message` cost_eur (LLM tokens priced at wholesale ×1.5):
+
+| Node type | Excluded from flow.step rate? | Billed via |
+|-----------|-------------------------------|------------|
+| `core:llm` | ✅ excluded | AI Wallet (token cost) |
+| `core:embedding` | ✅ excluded | AI Wallet (token cost) |
+| `core:vector_search` | ✅ excluded | AI Wallet (token cost) |
+| `ai:*` (KB pipeline nodes) | ✅ excluded | AI Wallet (token cost) |
+| `core:noop`, `core:http_request`, `core:transform`, `core:condition`, `core:formula_eval`, `core:calculator`, `core:loop`, `core:database`, `core:redis`, `core:delay`, `core:aggregate`, `core:script`, `core:expression` | **charged** | flow.step flat rate |
+
+### Env-var control
+
+The rate is configurable without code change:
+
+```bash
+FLOW_STEP_COST_EUR=0.001   # default; ops can tune per deployment
+```
+
+Read by the usage-consumer cron at startup. Invalid/negative values fall back to the default with a WARN log.
+
+### Example
+
+| Scenario | Steps | Rate | Cost |
+|----------|-------|------|------|
+| 1,000 non-AI steps/mo | 1,000 | €0.001 | **€1.00** |
+| 10,000 non-AI steps/mo (Growth-tier flow user) | 10,000 | €0.001 | **€10.00** |
+| 1,000 AI steps (core:llm) | 1,000 | €0.000 (excluded) | **€0.00** from this rate; token cost from AI Wallet |
+
+Step costs accumulate in `monthly_aggregates.total_cost_eur` alongside AI and other event costs.
+
+---
+
 ## 4. Module: Flows
 
 | Tier | Executions/mo | Max steps/exec | Concurrent runs | Scheduled triggers | EUR/mo | USD/mo |

--- a/docs/pricing/businesslogic-api-pricing.md
+++ b/docs/pricing/businesslogic-api-pricing.md
@@ -121,16 +121,19 @@ Bought ad-hoc or auto-attached when limits are hit (only with auto-reload enable
 
 A "step" is a single node that successfully completes inside a flow execution (emitted as a `flow.step` usage event). The flat rate is applied by the usage-consumer aggregator during hourly rollup into `monthly_aggregates.total_cost_eur`.
 
-### AI step exclusion
+### AI + internal step exclusion
 
-Steps running AI-node types are **not charged** as flow steps — they are already debited from the AI Wallet via `ai.message` cost_eur (LLM tokens priced at wholesale ×1.5):
+Two classes of steps are **not charged** as flow steps:
 
-| Node type | Excluded from flow.step rate? | Billed via |
-|-----------|-------------------------------|------------|
-| `core:llm` | ✅ excluded | AI Wallet (token cost) |
-| `core:embedding` | ✅ excluded | AI Wallet (token cost) |
-| `core:vector_search` | ✅ excluded | AI Wallet (token cost) |
-| `ai:*` (KB pipeline nodes) | ✅ excluded | AI Wallet (token cost) |
+1. **AI steps billed via AI Wallet** — LLM token cost flows through `ai.message` events (wholesale ×1.5 pricing).
+2. **Internal/local-compute steps** — zero marginal cost to us, so we don't meter them. Encourages heavy KB ingestion and search without per-step friction.
+
+| Node type | Excluded from flow.step rate? | Why |
+|-----------|-------------------------------|-----|
+| `core:llm` | ✅ excluded | Billed via AI Wallet (LLM token cost) |
+| `core:embedding` | ✅ excluded | **Free** — local ONNX inference, zero API cost |
+| `core:vector_search` | ✅ excluded | **Free** — local pgvector query |
+| `ai:*` (KB pipeline: `store_vectors`, `parse_document`, `filter_unchanged`, `merge_rrf`, `update_status`, `text_search`, `chunk_text`) | ✅ excluded | **Free** — internal housekeeping, encourages KB ingestion |
 | `core:noop`, `core:http_request`, `core:transform`, `core:condition`, `core:formula_eval`, `core:calculator`, `core:loop`, `core:database`, `core:redis`, `core:delay`, `core:aggregate`, `core:script`, `core:expression` | **charged** | flow.step flat rate |
 
 ### Env-var control
@@ -150,6 +153,7 @@ Read by the usage-consumer cron at startup. Invalid/negative values fall back to
 | 1,000 non-AI steps/mo | 1,000 | €0.001 | **€1.00** |
 | 10,000 non-AI steps/mo (Growth-tier flow user) | 10,000 | €0.001 | **€10.00** |
 | 1,000 AI steps (core:llm) | 1,000 | €0.000 (excluded) | **€0.00** from this rate; token cost from AI Wallet |
+| 1,000 KB-pipeline steps (ai:*, core:embedding, core:vector_search) | 1,000 | €0.000 (excluded) | **€0.00** — free internal compute |
 
 Step costs accumulate in `monthly_aggregates.total_cost_eur` alongside AI and other event costs.
 

--- a/docs/reports/db-admin-2026-04-21-task-43-flow-step-cost-083015.md
+++ b/docs/reports/db-admin-2026-04-21-task-43-flow-step-cost-083015.md
@@ -1,0 +1,91 @@
+# DB Admin Report — task-43: flow.step flat-rate cost aggregation
+
+**Slug:** task-43-flow-step-cost
+**Date:** 2026-04-21
+**Phase:** done
+**Severity:** LOW
+**Status:** APPLIED
+
+## Task
+Add p_flow_step_cost_eur parameter to aggregate_usage_events(); compute cost_eur for non-AI flow.step events (step_kind NOT LIKE 'ai:%' AND NOT IN core:llm,core:embedding,core:vector_search). Migration 037. Preserve all existing behavior (advisory lock, batch cap, CTE-returning, touched_accounts).
+
+## Snapshots Taken
+- pre PG dump:   infrastructure/db-snapshots/pre_task-43-flow-step-cost_20260421_082532.sql.gz
+- pre schema:    services/cms/snapshots/pre_task-43-flow-step-cost_20260421_082538.yaml
+- post PG dump:  infrastructure/db-snapshots/post_task-43-flow-step-cost_20260421_083003.sql.gz
+- post schema:   services/cms/snapshots/post_task-43-flow-step-cost_20260421_083010.yaml
+
+## Classification
+MINOR — additive SQL function replacement. No table/column/data changes.
+
+## Changes Applied
+1. Dropped old single-parameter overload `aggregate_usage_events(integer)` (migration 036 shape)
+2. Created new two-parameter overload `aggregate_usage_events(integer DEFAULT 100000, numeric DEFAULT 0.001)`
+3. Modified total_cost_eur computation: non-AI flow.step events contribute p_flow_step_cost_eur per step
+
+### AI step detection logic
+```sql
+WHEN event_kind = 'flow.step'
+ AND (
+      (metadata->>'step_kind') LIKE 'ai:%'
+   OR (metadata->>'step_kind') IN ('core:llm', 'core:embedding', 'core:vector_search')
+     )
+THEN COALESCE(cost_eur, 0)     -- AI steps: use existing cost_eur (not double-billed)
+WHEN event_kind = 'flow.step'
+THEN p_flow_step_cost_eur       -- non-AI steps: flat rate
+ELSE COALESCE(cost_eur, 0)     -- all other event kinds: unchanged
+```
+
+## Phase 4.5 — Data-Loss Risk Audit
+
+### Destructive operations detected
+- DROP FUNCTION aggregate_usage_events(integer) — drops old overload (not a table/column; no user data)
+
+### Baseline (captured 2026-04-21 08:25)
+| Table | Rows |
+|-------|------|
+| public.usage_events | 5 |
+| public.monthly_aggregates | 5 |
+
+### Downstream usage
+- services/cms/extensions/local/project-extension-usage-consumer/src/cron.ts:39 — sole production caller; will be updated in subsequent cron.ts change
+
+### Migration plan
+Additive replacement — no data migration required. Old function signature dropped (no data); new signature has DEFAULT for both parameters so old call `aggregate_usage_events(100000)` continues to work until cron.ts is updated.
+
+### Acceptance criteria (post-apply)
+- public.usage_events: row count = 5 (preserved — no data changes)
+- public.monthly_aggregates: row count = 5 (preserved — no data changes)
+
+## Phase 6.5 — Post-Apply Integrity Verification
+
+| Table | Baseline rows | Post-apply rows | Expected | Result |
+|-------|---------------|-----------------|----------|--------|
+| public.usage_events | 5 | 5 | preserved | PASS |
+| public.monthly_aggregates | 5 | 5 | preserved | PASS |
+
+Verdict: PASS
+
+## Migration Scripts
+- migrations/cms/037_aggregate_usage_events_flow_step_cost.sql
+- migrations/cms/037_aggregate_usage_events_flow_step_cost_down.sql
+
+## Diff Output
+Function replaced: `public.aggregate_usage_events` — signature changed from `(integer)` to `(integer, numeric)`. No table/column/index/constraint changes.
+
+## Downstream Impact
+- cron.ts will be updated in the same task to pass p_flow_step_cost_eur from FLOW_STEP_COST_EUR env var.
+
+## Rollback Plan
+```bash
+docker compose -f infrastructure/docker/docker-compose.dev.yml exec -T postgres \
+  psql -U directus -d directus -v ON_ERROR_STOP=1 -f - \
+  < migrations/cms/037_aggregate_usage_events_flow_step_cost_down.sql
+# or restore from pre snapshot:
+gunzip -c infrastructure/db-snapshots/pre_task-43-flow-step-cost_20260421_082532.sql.gz | \
+  docker compose -f infrastructure/docker/docker-compose.dev.yml exec -T postgres \
+  psql -U directus -d directus
+```
+
+## Follow-up
+- cron.ts update (read FLOW_STEP_COST_EUR env, pass to function) — in progress same task

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -280,7 +280,7 @@ Infrastructure and multi-service concerns.
 | 55 | 🟡 Onboarding guard stale-closure on logout→re-login in same tab (P2, follow-up to 50) | **completed 2026-04-20** (`321431c`) | [cross-cutting/55-onboarding-guard-logout-reentry.md](cross-cutting/55-onboarding-guard-logout-reentry.md) |
 | 56 | 🟠 **P1: Stripe webhook observability** — persist every hit + admin "Billing Health" panel + startup validation (from task 48 dev-session drift) | **completed 2026-04-20** | [cross-cutting/56-stripe-webhook-observability.md](cross-cutting/56-stripe-webhook-observability.md) |
 | 57 | 🟡 P2: Stripe reconciliation cron — defense-in-depth for missed webhooks | **completed 2026-04-21** (`7caf27e` + `5843c1e` — autoPagingEach + shared provisioning + is_auto_reload + quota-err; 142 tests) | [cross-cutting/57-stripe-reconciliation-cron.md](cross-cutting/57-stripe-reconciliation-cron.md) |
-| 58 | Post-Sprint-B follow-ups bundle — 12 minor polish items surfaced in reviews | planned | [cross-cutting/58-post-sprint-b-followups-cleanup.md](cross-cutting/58-post-sprint-b-followups-cleanup.md) |
+| 58 | Post-Sprint-B follow-ups bundle — 12 minor polish items surfaced in reviews | **completed 2026-04-20** (3 commits — 58.4 NOP, 58.9 WONTFIX, all others done; +7 tests) | [cross-cutting/58-post-sprint-b-followups-cleanup.md](cross-cutting/58-post-sprint-b-followups-cleanup.md) |
 
 ---
 

--- a/docs/tasks/cross-cutting/43-flow-step-cost-rate.md
+++ b/docs/tasks/cross-cutting/43-flow-step-cost-rate.md
@@ -1,46 +1,57 @@
-# 43. `flow.step` cost rate — pricing decision required
+# 43. `flow.step` cost rate — flat rate (B), env-configurable
 
-**Status:** planned (pricing decision, not engineering)
-**Severity:** LOW — events are emitted, aggregated, and displayed; just no `cost_eur` per step
+**Status:** completed
+**Decision:** Option B — flat rate €0.001/step, env-var `FLOW_STEP_COST_EUR`, AI steps excluded
+**Severity:** LOW
 **Source:** Sprint B task 20 implementation — `flow.step` wired end-to-end but no cost rate defined
-**Owner:** product/pricing (not engineering)
+**Owner:** dm@coignite.dk
 
-## Problem
+## Decision
 
-Sprint B task 20 wired `flow.step` emit on every successful node completion in `flow-engine/executor/mod.rs`. Events land in `usage_events` with `cost_eur = NULL`. Aggregator (task 21) sums them into `monthly_aggregates.flow_steps` counter correctly.
+**Option B selected:** flat rate per non-AI flow.step.
 
-But the pricing model has not decided whether flow steps cost separately from flow executions:
-- Option A: steps are free; billing is per-execution only (`flow.execution` carries cost)
-- Option B: steps have a per-step cost (e.g., €0.001/step); execution cost is additional flat rate
-- Option C: step cost varies by step type (AI nodes cost more than HTTP nodes) — requires metadata-based cost lookup
+- Rate: **€0.001/step** (1 millicent) — ops-tunable via `FLOW_STEP_COST_EUR` env var
+- AI steps (`core:llm`, `core:embedding`, `core:vector_search`, `ai:*`) are **excluded** — they are already billed through the AI Wallet via `ai.message` cost_eur. Double-billing prevented.
+- step_kind identified from `metadata->>'step_kind'` in `usage_events` (emitted by the Rust executor as `node_type`)
 
-Until decided, `flow_steps` counter increments but never contributes to `total_cost_eur` in `monthly_aggregates`.
+## Implementation
 
-## Required decision
+### Migration 037 — aggregator function update
 
-Product/pricing team (dm@coignite.dk):
+`public.aggregate_usage_events(p_batch_size int DEFAULT 100000, p_flow_step_cost_eur numeric DEFAULT 0.001)`
 
-1. Is flow-step a billable unit?
-2. If yes, flat rate or type-dependent?
-3. If type-dependent, what's the rate card per `step_kind`? (AI node, HTTP request, formula call, KB search-from-flow, conditional, etc.)
-4. Does it belong in the Flows tier price or separately metered?
+Non-AI `flow.step` events contribute `p_flow_step_cost_eur` to `total_cost_eur`. AI steps use their existing `cost_eur` (or 0).
 
-## Implementation (once decided)
+- Up: `migrations/cms/037_aggregate_usage_events_flow_step_cost.sql`
+- Down: `migrations/cms/037_aggregate_usage_events_flow_step_cost_down.sql`
+- DB admin report: `docs/reports/db-admin-2026-04-21-task-43-flow-step-cost-083015.md`
 
-If A (steps free): no engineering work; just document and close.
+### Cron handler
 
-If B (flat rate): update the aggregator SQL function to set `cost_eur = quantity * flat_rate` for `flow.step` events in the monthly rollup. One-line migration via db-admin.
+`services/cms/extensions/local/project-extension-usage-consumer/src/cron.ts`:
+- `parseFlowStepCostEur(env)` — reads `FLOW_STEP_COST_EUR`, validates (finite ≥ 0), falls back to 0.001 with WARN
+- `runAggregation(db, batchSize, flowStepCostEur)` — passes rate as second SQL param
+- `buildAggregateUsageEventsCron(db, logger, getRedis, env)` — wires env → rate
 
-If C (type-dependent): requires a rate-card table `flow_step_rates(step_kind text, cost_eur_per_step numeric)` + aggregator JOIN against it. Medium-sized task.
+### Env var
+
+`FLOW_STEP_COST_EUR=0.001` — documented in `infrastructure/docker/.env.example`
+
+## Key Tasks
+
+- [x] Migration 037 written + applied
+- [x] Down migration written
+- [x] cron.ts updated (parseFlowStepCostEur + runAggregation signature + buildAggregateUsageEventsCron env param)
+- [x] index.ts updated (pass env to buildAggregateUsageEventsCron)
+- [x] .env.example documented
+- [x] docs/pricing/businesslogic-api-pricing.md section 3b added
+- [x] Unit tests: parseFlowStepCostEur (7 cases), runAggregation (updated SQL assertion), buildAggregateUsageEventsCron (3 new env tests)
+- [x] E2E test: total_cost_eur updated to include flow.step rate (9 steps × €0.001 = €0.009 added)
 
 ## Acceptance
 
-- Decision documented in `docs/pricing/businesslogic-api-pricing.md`
-- Implementation matches decision
-- `monthly_aggregates` includes flow-step cost in `total_cost_eur` (if billable)
-- Dashboard/ops view reflects step volume regardless of billable status
-
-## Estimate
-
-- Decision: 30min conversation + doc update
-- Implementation: 30min (A), 1h (B), half day (C)
+- [x] Decision documented in `docs/pricing/businesslogic-api-pricing.md` (section 3b)
+- [x] Implementation matches decision (B: flat rate, env-configurable)
+- [x] `monthly_aggregates.total_cost_eur` includes non-AI flow-step cost
+- [x] AI steps excluded (step_kind LIKE 'ai:%' OR IN core:llm/embedding/vector_search)
+- [x] 39/39 unit tests pass

--- a/docs/tasks/cross-cutting/52-ux-test-p1-cleanup-bundle.md
+++ b/docs/tasks/cross-cutting/52-ux-test-p1-cleanup-bundle.md
@@ -1,6 +1,6 @@
 # 52. 🟡 P1 bundle: Post-Sprint-B UX cleanup (from ux-tester 2026-04-20)
 
-**Status:** in-progress (52.1 + 52.2 + 52.4 done; 52.3 cancelled — directus_* constraint; pending manual admin-UI + browser-qa)
+**Status:** completed (52.1 + 52.2 + 52.4 shipped in Sprint B; 52.3 resolved 2026-04-21 — user deleted `account.subscriptions` ghost field via Directus Admin UI, verified clean in `directus_fields`)
 **Severity:** P1 (bundled polish) — each item LOW individually, but together they degrade Sprint B's perceived quality
 **Source:** ux-tester 2026-04-20 (Sarah persona, full report: `docs/reports/ux-test-2026-04-20-sarah-billing.md`)
 
@@ -69,11 +69,10 @@ Likely a shared utility or a pinia action wrapper. Look at `services/cms/extensi
   - `directus_permissions` id=163: User Access × ai_prompts × read (filter: `{}`)
   - `directus_permissions` id=164: User Access × ai_conversations × read (filter: `{"account":{"_eq":"$CURRENT_USER.active_account"}}`)
   - Prod re-apply: see `docs/reports/db-admin-2026-04-20-task-52-cancelled-directus-constraint-*.md`
-- [ ] 52.3: account list view loads for a new account with no subscriptions — **CANCELLED** (directus_* constraint)
-  - Ghost field `account.subscriptions` (directus_fields id=109) still present
-  - Fix requires deleting from `directus_fields` — forbidden under "no directus_* collection changes" rule
+- [x] 52.3: account list view loads for a new account with no subscriptions — **RESOLVED 2026-04-21**
+  - User deleted `account.subscriptions` ghost field manually via Directus Admin UI
+  - Verified: `SELECT * FROM directus_fields WHERE collection='account' AND field LIKE '%subscription%'` → only legitimate `exempt_from_subscription` remains
   - Forensic migration preserved at `migrations/cms/dryrun_cancelled_035_task_52_account_subscriptions_ghost_field.sql`
-  - User must apply via Directus Admin UI: Settings → Data Model → account collection → delete `subscriptions` field
 - [x] 52.4: 403/401/404/500 errors show human-readable messages in 3+ places tested
   - `formatApiError` utility created + unit-tested in both extensions (13 test cases each)
   - Wired into: `use-account.ts` (8 catch blocks), `use-onboarding.ts` (2 catch blocks), `use-chat.ts` (1 catch block), `subscription-info.vue` (1 catch block), `module.vue` handleTopup (1 catch block)

--- a/docs/tasks/cross-cutting/58-post-sprint-b-followups-cleanup.md
+++ b/docs/tasks/cross-cutting/58-post-sprint-b-followups-cleanup.md
@@ -1,73 +1,78 @@
 # 58. Post-Sprint-B follow-ups — minor polish bundle
 
-**Status:** planned
+**Status:** completed
 **Severity:** LOW — all items are cosmetic / test-coverage / optional hardening. None block production.
-**Source:** Code reviews on tasks 56, 57, 41, 42, 45, 46 (branch `dm/post-sprint-b-followups`, 2026-04-20/21).
+**Source:** Code reviews on tasks 56, 57, 41, 42, 45, 46 (branch `dm/task-43-58-followups`, 2026-04-20).
+**Branch:** `dm/task-43-58-followups`
 
 ## Bundle rationale
 
-Ten low-severity follow-up items surfaced across the six tasks. Each is <1h. Bundled for efficiency.
+12 low-severity follow-up items surfaced across the six tasks. Each is <1h. Bundled for efficiency.
 
 ## Items
 
 ### 58.1 — Task 56: `400_missing_metadata` enum value unused
-
-`webhook-log.ts` declares `'400_missing_metadata'` as a status literal and `webhook-route.ts` permits it, but no code path emits it. Either drop from the enum OR wire into at least one downstream handler (e.g., `handleCheckoutCompleted` when `metadata.product_kind` is absent).
+**DONE** — dropped from `WebhookLogStatus` type in `webhook-log.ts`. Comment added explaining when to re-add it.
 
 ### 58.2 — Task 56: Green banner logic narrower than spec
-
-`webhook-health.ts::computeBanner`: green requires zero signature failures in last 1h; spec literally says "zero failures" of any kind. Decide: widen to all failure types or accept current pragmatic reading (parse/handler failures are rare).
+**DONE** — `computeBanner` now takes `anyFailures1h` (queried via `whereNotIn(['200','reconciled'])`) in addition to `signatureFailures1h`. Green requires both zero sig-fails AND zero any-failures in last 1h. New test added: `returns NEUTRAL (not green) when non-sig failure present in 1h`.
 
 ### 58.3 — Task 56: HTTP 503 vs 500 when webhook secret missing at runtime
-
-`webhook-route.ts` returns HTTP 500 when `STRIPE_WEBHOOK_SECRET` is absent at runtime (pre-signature path). Startup validation should already fail boot, so this is truly defensive — but if it ever fires, 503 (service unavailable) is more semantically correct than 500.
+**DONE** — `webhook-route.ts` now returns `res.status(503)` on the missing-secret path. Test updated to assert 503.
 
 ### 58.4 — Task 56: Billing Health panel keep-alive polling
-
-`billing-health.vue` polls via `setInterval(60000)` and clears on `onBeforeUnmount`. If the observatory module uses `<keep-alive>`, the panel keeps polling while hidden. Consider `onActivated` / `onDeactivated` hooks.
+**CLOSED / NOP** — investigated `project-extension-ai-observatory`: the observatory module does NOT use `<keep-alive>` anywhere. `onBeforeUnmount` cleanup is sufficient. No code change needed.
 
 ### 58.5 — Task 56: Replace `req: any` / `res: any` with typed shapes
-
-`webhook-route.ts:39` and `webhook-health.ts:196` use `any` for req/res. Inline a minimal shape (same pattern the file uses for `WebhookRouteDeps`) for better IDE assist and drift protection.
+**DONE** — `webhook-route.ts`: added `WebhookReq` and `WebhookRes` interfaces; handler signature updated. `webhook-health.ts`: added `HealthReq` and `HealthRes` interfaces; route handler updated.
 
 ### 58.6 — Task 57: Rollback-injection test for `provisionWalletTopup`
-
-Atomicity of the 3-INSERT transaction is correct-by-construction (idiomatic knex) but uncovered by a failure-injection test. Add a test that mocks the ledger INSERT to throw and asserts topup + wallet rows are NOT visible outside the transaction.
+**DONE** — Added test in `reconciliation.test.ts`: mocks ledger INSERT to throw, asserts transaction is rolled back, committed arrays empty, and `result.errors === 1`.
 
 ### 58.7 — Task 57: Quota-refresh-failure branch uncovered
-
-`reconciliation.ts` plumbs a quota-refresh error into the reconcile log's `error_message` and increments `errors` instead of `reconciled`. Logic is correct but no unit test exercises the branch. Add a test where the mocked `refresh_feature_quotas` throws.
+**DONE** — Added test in `reconciliation.test.ts`: mocks `refresh_feature_quotas` to throw, asserts `result.errors === 1`, `result.reconciled === 0`, and the reconcile log row has `error_message` containing `"quota refresh failed"` + the actual error text.
 
 ### 58.8 — Task 57: Minor date-math duplication in `handleCheckoutCompleted` UPDATE branch
-
-The UPDATE branch in `webhook-handlers.ts` recomputes `current_period_start/end` and `trial_start/end` that the shared helper (`provisioning.ts`) also computes on the INSERT branch. Inputs are identical, so drift risk is very low, but extracting a shared date-math helper would seal the remaining surface.
+**DONE** — Extracted `computeSubscriptionDates(stripeSub)` helper into `provisioning.ts`. Used in `provisionSubscriptionRow` (INSERT path) and `handleCheckoutCompleted` UPDATE branch. Both paths now share one date-conversion helper.
 
 ### 58.9 — Task 42: Channel name constants shared cross-language
-
-`bl:gw_apikey_ai_spend:invalidated` and `bl:gw_apikey_kb_search:invalidated` are duplicated in 3 services (gateway Go, ai-api JS, usage-consumer TS). Consider a shared `packages/bl-events/channels.json` (or similar) consumed via codegen. Pattern would also absorb `bl:monthly_aggregates:invalidated` + `bl:feature_quotas:invalidated`. Only worth doing once a 5th channel is added.
+**WONTFIX** — Only 2 channels (`bl:gw_apikey_ai_spend:invalidated`, `bl:gw_apikey_kb_search:invalidated`). Cross-language shared-const file is overkill at this scale. Revisit when 5+ channels exist. Tests verify each literal in-situ.
 
 ### 58.10 — Task 42: Dedicated gateway subscriber Redis client
-
-Gateway's `StartCacheInvalidationSubscriber` uses the main `rdb` client. go-redis PubSub internally takes its own pooled connection so no starvation risk, but formula-api's pattern uses a dedicated `quotaSubRedis` with explicit retryStrategy. Cosmetic symmetry: add a dedicated client for clarity.
+**DONE** — `main.go`: added `subRdb := redis.NewClient(subOpts)` dedicated client for `StartCacheInvalidationSubscriber`. `subRdb.Close()` called when the goroutine exits. Matches formula-api's `quotaSubRedis` pattern.
 
 ### 58.11 — Task 42: Negative test — publish skipped on transaction rollback
-
-`wallet-debit-publish.test.js` asserts publish happens when commit succeeds. Missing: assert publish is skipped when balance-insufficient or monthly-cap triggers ROLLBACK. 6th test to harden the contract.
+**DONE** — Added 6th test in `wallet-debit-publish.test.js`: sets wallet balance to `0.0001` EUR which cannot cover a 1¢ debit → ROLLBACK path → asserts `result.ok === false` and `published.length === 0`.
 
 ### 58.12 — Task 46: `welcome-wizard.vue` tile buttons lack `aria-pressed`
+**DONE** — Tiles are native `<button>` elements (not `v-button`), so `:aria-pressed="selectedIntent === tile.intent"` binds directly. Added `role="group" aria-label="Choose your goal"` to `.intent-grid` container. Added `vue-router` alias stub to `vitest.config.ts` + 4 a11y tests in `__tests__/welcome-wizard.a11y.test.ts`.
 
-The 2-tile onboarding picker in `project-extension-account/src/components/welcome-wizard.vue` uses Directus `v-button` without explicit `aria-pressed` on the selected state. Non-trivial because the tiles are composed components, not raw `<button>`s.
+## Implementation summary
+
+| Item | Status | Files |
+|------|--------|-------|
+| 58.1 | DONE | webhook-log.ts |
+| 58.2 | DONE | webhook-health.ts, webhook-health.test.ts |
+| 58.3 | DONE | webhook-route.ts, webhook-route.test.ts |
+| 58.4 | NOP (no keep-alive in observatory) | — |
+| 58.5 | DONE | webhook-route.ts, webhook-health.ts |
+| 58.6 | DONE | reconciliation.test.ts (+1 test) |
+| 58.7 | DONE | reconciliation.test.ts (+1 test) |
+| 58.8 | DONE | provisioning.ts, webhook-handlers.ts |
+| 58.9 | WONTFIX | task doc only |
+| 58.10 | DONE | main.go (gateway) |
+| 58.11 | DONE | wallet-debit-publish.test.js (+1 test) |
+| 58.12 | DONE | welcome-wizard.vue, welcome-wizard.a11y.test.ts, vitest.config.ts, __mocks__/vue-router.ts |
+
+## Test delta
+
+- stripe extension: 148 → 150 (+2)
+- account extension: 75 → 79 (+4)
+- ai-api: 312 → 313 (+1)
+- gateway: builds clean
 
 ## Acceptance
 
-- Each item addressed or explicitly dismissed (with rationale in this doc)
-- Full test suite still green
-- No scope creep — items outside this list go into new tasks
-
-## Estimate
-
-6-8h total (bundled). Most are 20-40min each.
-
-## Dependencies
-
-None beyond the branch landing. These are all polish on shipped code.
+- All 12 items addressed or explicitly dismissed
+- Full test suite green
+- No scope creep

--- a/infrastructure/docker/.env.example
+++ b/infrastructure/docker/.env.example
@@ -144,5 +144,13 @@ FLOW_REDIS_URL=redis://redis:6379
 FLOW_PORT=3100
 RUST_LOG=info
 
+# ── Flow Step Billing ────────────────────────────────────────────────
+# Flat rate per non-AI flow.step event, in EUR (default: €0.001 = 1 millicent/step).
+# AI-node steps (core:llm, core:embedding, core:vector_search, ai:*) are excluded —
+# they are already billed through the AI Wallet via ai.message cost_eur.
+# Example: 1000 non-AI steps × €0.001 = €1.00
+# Passed to aggregate_usage_events(p_batch_size, p_flow_step_cost_eur) by the usage-consumer cron.
+FLOW_STEP_COST_EUR=0.001
+
 # ── Sentry ──────────────────────────────────────────────────────────
 # DE_SENTRY_DSN=https://...@sentry.coignite.dk/16

--- a/migrations/cms/037_aggregate_usage_events_flow_step_cost.sql
+++ b/migrations/cms/037_aggregate_usage_events_flow_step_cost.sql
@@ -1,0 +1,161 @@
+-- Migration 037: aggregate_usage_events — flow.step flat-rate cost
+--
+-- Adds p_flow_step_cost_eur NUMERIC parameter (default 0.001 = €0.001/step).
+-- Non-AI flow.step events now contribute p_flow_step_cost_eur to total_cost_eur.
+-- AI steps excluded (they are already billed via ai.message/ai.completion events):
+--   step_kind LIKE 'ai:%' OR step_kind IN ('core:llm','core:embedding','core:vector_search')
+--
+-- All other behaviour (advisory lock, batch cap, CTE-returning, touched_accounts) preserved.
+--
+-- Drops the old single-parameter overload (migration 036) to avoid ambiguity on no-arg calls.
+-- Callers that pass p_batch_size positionally continue to work; the new parameter is second.
+
+DROP FUNCTION IF EXISTS public.aggregate_usage_events(integer);
+
+CREATE OR REPLACE FUNCTION public.aggregate_usage_events(
+  p_batch_size         int     DEFAULT 100000,
+  p_flow_step_cost_eur numeric DEFAULT 0.001
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_events_aggregated bigint := 0;
+  v_accounts_touched  bigint := 0;
+  v_periods_touched   bigint := 0;
+  v_lag_seconds       numeric := 0;
+  v_touched_accounts  uuid[] := '{}';
+  v_oldest_unagg      timestamptz;
+BEGIN
+  -- I1: Block concurrent invocations for the duration of this transaction
+  PERFORM pg_advisory_xact_lock(hashtext('aggregate_usage_events'));
+
+  -- Capture lag before we mark rows as aggregated (reflects oldest event in remaining backlog)
+  SELECT MIN(occurred_at) INTO v_oldest_unagg
+  FROM public.usage_events
+  WHERE aggregated_at IS NULL;
+
+  IF v_oldest_unagg IS NOT NULL THEN
+    v_lag_seconds := EXTRACT(EPOCH FROM (NOW() - v_oldest_unagg));
+  END IF;
+
+  -- I3: Limit source rows before GROUP BY to cap memory per batch
+  WITH events_to_agg AS (
+    SELECT id, account_id, occurred_at, event_kind, quantity, cost_eur, metadata
+    FROM public.usage_events
+    WHERE aggregated_at IS NULL
+    ORDER BY occurred_at
+    LIMIT p_batch_size
+  ),
+  new_events AS (
+    SELECT
+      account_id,
+      to_char(occurred_at, 'YYYYMM')::int AS period_yyyymm,
+      COUNT(*) FILTER (WHERE event_kind = 'calc.call')                              AS calc_calls,
+      COUNT(*) FILTER (WHERE event_kind = 'kb.search')                              AS kb_searches,
+      COUNT(*) FILTER (WHERE event_kind = 'kb.ask')                                AS kb_asks,
+      COALESCE(SUM(quantity) FILTER (WHERE event_kind = 'embed.tokens'), 0)        AS kb_embed_tokens,
+      COUNT(*) FILTER (WHERE event_kind = 'ai.message')                            AS ai_messages,
+      COALESCE(SUM(
+        CASE
+          WHEN metadata ? 'input_tokens'
+           AND metadata->>'input_tokens' ~ '^[0-9]+$'
+          THEN (metadata->>'input_tokens')::bigint
+          ELSE 0
+        END
+      ) FILTER (WHERE event_kind = 'ai.message'), 0)                               AS ai_input_tokens,
+      COALESCE(SUM(
+        CASE
+          WHEN metadata ? 'output_tokens'
+           AND metadata->>'output_tokens' ~ '^[0-9]+$'
+          THEN (metadata->>'output_tokens')::bigint
+          ELSE 0
+        END
+      ) FILTER (WHERE event_kind = 'ai.message'), 0)                               AS ai_output_tokens,
+      COALESCE(SUM(cost_eur) FILTER (WHERE event_kind IN ('ai.message', 'embed.tokens')), 0) AS ai_cost_eur,
+      COUNT(*) FILTER (WHERE event_kind = 'flow.execution')                        AS flow_executions,
+      COUNT(*) FILTER (WHERE event_kind = 'flow.step')                             AS flow_steps,
+      COUNT(*) FILTER (WHERE event_kind = 'flow.failed')                           AS flow_failed,
+      -- total_cost_eur: existing events with cost_eur + flat rate for non-AI flow.step events.
+      -- AI steps excluded: they are already billed via ai.message cost_eur (double-bill prevention).
+      -- Non-AI step_kinds: core:* except core:llm, core:embedding, core:vector_search.
+      COALESCE(SUM(
+        CASE
+          WHEN event_kind = 'flow.step'
+           AND (
+                (metadata->>'step_kind') LIKE 'ai:%'
+             OR (metadata->>'step_kind') IN ('core:llm', 'core:embedding', 'core:vector_search')
+               )
+          THEN COALESCE(cost_eur, 0)
+          WHEN event_kind = 'flow.step'
+          THEN p_flow_step_cost_eur
+          ELSE COALESCE(cost_eur, 0)
+        END
+      ), 0)                                                                         AS total_cost_eur,
+      array_agg(id)                                                                AS event_ids
+    FROM events_to_agg
+    GROUP BY account_id, to_char(occurred_at, 'YYYYMM')::int
+  ),
+  upserted AS (
+    INSERT INTO public.monthly_aggregates (
+      account_id, period_yyyymm,
+      calc_calls,
+      kb_searches, kb_asks, kb_embed_tokens,
+      ai_messages, ai_input_tokens, ai_output_tokens, ai_cost_eur,
+      flow_executions, flow_steps, flow_failed,
+      total_cost_eur,
+      refreshed_at, date_updated
+    )
+    SELECT
+      account_id, period_yyyymm,
+      calc_calls,
+      kb_searches, kb_asks, kb_embed_tokens,
+      ai_messages, ai_input_tokens, ai_output_tokens, ai_cost_eur,
+      flow_executions, flow_steps, flow_failed,
+      total_cost_eur,
+      NOW(), NOW()
+    FROM new_events
+    ON CONFLICT (account_id, period_yyyymm) DO UPDATE SET
+      calc_calls              = monthly_aggregates.calc_calls              + EXCLUDED.calc_calls,
+      kb_searches             = monthly_aggregates.kb_searches             + EXCLUDED.kb_searches,
+      kb_asks                 = monthly_aggregates.kb_asks                 + EXCLUDED.kb_asks,
+      kb_embed_tokens         = monthly_aggregates.kb_embed_tokens         + EXCLUDED.kb_embed_tokens,
+      ai_messages             = monthly_aggregates.ai_messages             + EXCLUDED.ai_messages,
+      ai_input_tokens         = monthly_aggregates.ai_input_tokens         + EXCLUDED.ai_input_tokens,
+      ai_output_tokens        = monthly_aggregates.ai_output_tokens        + EXCLUDED.ai_output_tokens,
+      ai_cost_eur             = monthly_aggregates.ai_cost_eur             + EXCLUDED.ai_cost_eur,
+      flow_executions         = monthly_aggregates.flow_executions         + EXCLUDED.flow_executions,
+      flow_steps              = monthly_aggregates.flow_steps              + EXCLUDED.flow_steps,
+      flow_failed             = monthly_aggregates.flow_failed             + EXCLUDED.flow_failed,
+      total_cost_eur          = monthly_aggregates.total_cost_eur          + EXCLUDED.total_cost_eur,
+      refreshed_at            = NOW(),
+      date_updated            = NOW()
+    RETURNING account_id, period_yyyymm
+  ),
+  marked AS (
+    UPDATE public.usage_events
+    SET aggregated_at = NOW()
+    WHERE id = ANY(
+      ARRAY(
+        SELECT unnest(event_ids)
+        FROM new_events
+      )::bigint[]
+    )
+    RETURNING id
+  )
+  SELECT
+    (SELECT COUNT(*) FROM marked),
+    (SELECT COUNT(DISTINCT account_id) FROM upserted),
+    (SELECT COUNT(*) FROM upserted),
+    (SELECT array_agg(DISTINCT account_id) FROM upserted)
+  INTO v_events_aggregated, v_accounts_touched, v_periods_touched, v_touched_accounts;
+
+  RETURN jsonb_build_object(
+    'events_aggregated', v_events_aggregated,
+    'accounts_touched',  v_accounts_touched,
+    'periods_touched',   v_periods_touched,
+    'lag_seconds',       v_lag_seconds,
+    'touched_accounts',  COALESCE(to_jsonb(v_touched_accounts), '[]'::jsonb)
+  );
+END;
+$$;

--- a/migrations/cms/037_aggregate_usage_events_flow_step_cost_down.sql
+++ b/migrations/cms/037_aggregate_usage_events_flow_step_cost_down.sql
@@ -1,0 +1,135 @@
+-- Migration 037 rollback: revert aggregate_usage_events to pre-037 shape (migration 036 body).
+-- Removes p_flow_step_cost_eur parameter; reverts total_cost_eur to COALESCE(SUM(cost_eur),0).
+-- Drops the two-parameter overload added by 037; restores the single-parameter (036) signature.
+
+DROP FUNCTION IF EXISTS public.aggregate_usage_events(integer, numeric);
+
+CREATE OR REPLACE FUNCTION public.aggregate_usage_events(p_batch_size int DEFAULT 100000)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_events_aggregated bigint := 0;
+  v_accounts_touched  bigint := 0;
+  v_periods_touched   bigint := 0;
+  v_lag_seconds       numeric := 0;
+  v_touched_accounts  uuid[] := '{}';
+  v_oldest_unagg      timestamptz;
+BEGIN
+  -- I1: Block concurrent invocations for the duration of this transaction
+  PERFORM pg_advisory_xact_lock(hashtext('aggregate_usage_events'));
+
+  -- Capture lag before we mark rows as aggregated (reflects oldest event in remaining backlog)
+  SELECT MIN(occurred_at) INTO v_oldest_unagg
+  FROM public.usage_events
+  WHERE aggregated_at IS NULL;
+
+  IF v_oldest_unagg IS NOT NULL THEN
+    v_lag_seconds := EXTRACT(EPOCH FROM (NOW() - v_oldest_unagg));
+  END IF;
+
+  -- I3: Limit source rows before GROUP BY to cap memory per batch
+  WITH events_to_agg AS (
+    SELECT id, account_id, occurred_at, event_kind, quantity, cost_eur, metadata
+    FROM public.usage_events
+    WHERE aggregated_at IS NULL
+    ORDER BY occurred_at
+    LIMIT p_batch_size
+  ),
+  new_events AS (
+    SELECT
+      account_id,
+      to_char(occurred_at, 'YYYYMM')::int AS period_yyyymm,
+      COUNT(*) FILTER (WHERE event_kind = 'calc.call')                              AS calc_calls,
+      COUNT(*) FILTER (WHERE event_kind = 'kb.search')                              AS kb_searches,
+      COUNT(*) FILTER (WHERE event_kind = 'kb.ask')                                AS kb_asks,
+      COALESCE(SUM(quantity) FILTER (WHERE event_kind = 'embed.tokens'), 0)        AS kb_embed_tokens,
+      COUNT(*) FILTER (WHERE event_kind = 'ai.message')                            AS ai_messages,
+      COALESCE(SUM(
+        CASE
+          WHEN metadata ? 'input_tokens'
+           AND metadata->>'input_tokens' ~ '^[0-9]+$'
+          THEN (metadata->>'input_tokens')::bigint
+          ELSE 0
+        END
+      ) FILTER (WHERE event_kind = 'ai.message'), 0)                               AS ai_input_tokens,
+      COALESCE(SUM(
+        CASE
+          WHEN metadata ? 'output_tokens'
+           AND metadata->>'output_tokens' ~ '^[0-9]+$'
+          THEN (metadata->>'output_tokens')::bigint
+          ELSE 0
+        END
+      ) FILTER (WHERE event_kind = 'ai.message'), 0)                               AS ai_output_tokens,
+      COALESCE(SUM(cost_eur) FILTER (WHERE event_kind IN ('ai.message', 'embed.tokens')), 0) AS ai_cost_eur,
+      COUNT(*) FILTER (WHERE event_kind = 'flow.execution')                        AS flow_executions,
+      COUNT(*) FILTER (WHERE event_kind = 'flow.step')                             AS flow_steps,
+      COUNT(*) FILTER (WHERE event_kind = 'flow.failed')                           AS flow_failed,
+      COALESCE(SUM(cost_eur), 0)                                                   AS total_cost_eur,
+      array_agg(id)                                                                AS event_ids
+    FROM events_to_agg
+    GROUP BY account_id, to_char(occurred_at, 'YYYYMM')::int
+  ),
+  upserted AS (
+    INSERT INTO public.monthly_aggregates (
+      account_id, period_yyyymm,
+      calc_calls,
+      kb_searches, kb_asks, kb_embed_tokens,
+      ai_messages, ai_input_tokens, ai_output_tokens, ai_cost_eur,
+      flow_executions, flow_steps, flow_failed,
+      total_cost_eur,
+      refreshed_at, date_updated
+    )
+    SELECT
+      account_id, period_yyyymm,
+      calc_calls,
+      kb_searches, kb_asks, kb_embed_tokens,
+      ai_messages, ai_input_tokens, ai_output_tokens, ai_cost_eur,
+      flow_executions, flow_steps, flow_failed,
+      total_cost_eur,
+      NOW(), NOW()
+    FROM new_events
+    ON CONFLICT (account_id, period_yyyymm) DO UPDATE SET
+      calc_calls              = monthly_aggregates.calc_calls              + EXCLUDED.calc_calls,
+      kb_searches             = monthly_aggregates.kb_searches             + EXCLUDED.kb_searches,
+      kb_asks                 = monthly_aggregates.kb_asks                 + EXCLUDED.kb_asks,
+      kb_embed_tokens         = monthly_aggregates.kb_embed_tokens         + EXCLUDED.kb_embed_tokens,
+      ai_messages             = monthly_aggregates.ai_messages             + EXCLUDED.ai_messages,
+      ai_input_tokens         = monthly_aggregates.ai_input_tokens         + EXCLUDED.ai_input_tokens,
+      ai_output_tokens        = monthly_aggregates.ai_output_tokens        + EXCLUDED.ai_output_tokens,
+      ai_cost_eur             = monthly_aggregates.ai_cost_eur             + EXCLUDED.ai_cost_eur,
+      flow_executions         = monthly_aggregates.flow_executions         + EXCLUDED.flow_executions,
+      flow_steps              = monthly_aggregates.flow_steps              + EXCLUDED.flow_steps,
+      flow_failed             = monthly_aggregates.flow_failed             + EXCLUDED.flow_failed,
+      total_cost_eur          = monthly_aggregates.total_cost_eur          + EXCLUDED.total_cost_eur,
+      refreshed_at            = NOW(),
+      date_updated            = NOW()
+    RETURNING account_id, period_yyyymm
+  ),
+  marked AS (
+    UPDATE public.usage_events
+    SET aggregated_at = NOW()
+    WHERE id = ANY(
+      ARRAY(
+        SELECT unnest(event_ids)
+        FROM new_events
+      )::bigint[]
+    )
+    RETURNING id
+  )
+  SELECT
+    (SELECT COUNT(*) FROM marked),
+    (SELECT COUNT(DISTINCT account_id) FROM upserted),
+    (SELECT COUNT(*) FROM upserted),
+    (SELECT array_agg(DISTINCT account_id) FROM upserted)
+  INTO v_events_aggregated, v_accounts_touched, v_periods_touched, v_touched_accounts;
+
+  RETURN jsonb_build_object(
+    'events_aggregated', v_events_aggregated,
+    'accounts_touched',  v_accounts_touched,
+    'periods_touched',   v_periods_touched,
+    'lag_seconds',       v_lag_seconds,
+    'touched_accounts',  COALESCE(to_jsonb(v_touched_accounts), '[]'::jsonb)
+  );
+END;
+$$;

--- a/services/ai-api/test/wallet-debit-publish.test.js
+++ b/services/ai-api/test/wallet-debit-publish.test.js
@@ -192,4 +192,34 @@ describe('debitWallet gateway cache invalidation publish', () => {
     await new Promise(r => setTimeout(r, 10));
     assert.equal(published.length, 0, 'no publish for zero-cost event');
   });
+
+  it('does not publish when debit is rolled back due to insufficient balance (task 58.11)', async () => {
+    // Balance too low → ROLLBACK path → publish must NOT fire
+    const published = [];
+    const fakeRedis = {
+      async publish(channel, payload) { published.push({ channel, payload }); return 1; },
+    };
+
+    // Pool with a near-zero balance that can't cover even a 1¢ debit
+    const pool = makeMockPool({ balanceEur: '0.0001' });
+
+    const result = await debitWallet({
+      accountId: 'acc-pub-6',
+      costUsd: 0.01, // ~0.0092 EUR — exceeds 0.0001 balance
+      model: 'claude-sonnet-4-6',
+      module: 'ai',
+      eventKind: 'ai.message',
+      metadata: {},
+      apiKeyId: 'key-uuid-rollback',
+      pool,
+      redis: fakeRedis,
+    });
+
+    // Must be a 402 failure, not ok
+    assert.equal(result.ok, false, 'debit should fail with insufficient balance');
+    assert.equal(result.statusCode, 402);
+    // Allow any async fire-and-forget to settle
+    await new Promise(r => setTimeout(r, 20));
+    assert.equal(published.length, 0, 'must not publish on rollback path');
+  });
 });

--- a/services/cms/extensions/local/project-extension-account/__tests__/__mocks__/vue-router.ts
+++ b/services/cms/extensions/local/project-extension-account/__tests__/__mocks__/vue-router.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal vue-router stub for unit tests.
+ * The real vue-router is provided by the Directus host at runtime; this stub
+ * satisfies imports during vitest runs without requiring the package.
+ */
+import { vi } from 'vitest';
+
+export const useRouter = vi.fn(() => ({
+	push: vi.fn(),
+	replace: vi.fn(),
+	go: vi.fn(),
+	back: vi.fn(),
+	forward: vi.fn(),
+	currentRoute: { value: { path: '/', query: {}, params: {} } },
+}));
+
+export const useRoute = vi.fn(() => ({
+	path: '/',
+	query: {},
+	params: {},
+	name: null,
+	meta: {},
+}));
+
+export const RouterLink = { template: '<a><slot /></a>' };
+export const RouterView = { template: '<div><slot /></div>' };

--- a/services/cms/extensions/local/project-extension-account/__tests__/welcome-wizard.a11y.test.ts
+++ b/services/cms/extensions/local/project-extension-account/__tests__/welcome-wizard.a11y.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Task 58.12 — welcome-wizard intent-tile aria-pressed a11y test.
+ *
+ * Verifies that the 2+ tile buttons in the onboarding picker carry correct
+ * aria-pressed state so screen readers can announce selection.
+ */
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Module mocks (must be hoisted before component import) ────────────────────
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: vi.fn() }),
+	useRoute: () => ({ query: {} }),
+}));
+
+vi.mock('@directus/extensions-sdk', () => ({
+	useApi: () => ({}),
+}));
+
+vi.mock('../src/composables/use-account', () => ({
+	useAccount: () => ({
+		plans: { value: [] },
+		fetchPlans: vi.fn(),
+		startCheckout: vi.fn(),
+	}),
+}));
+
+vi.mock('../src/composables/use-onboarding', () => ({
+	useOnboarding: () => ({
+		captureIntent: vi.fn(),
+		markActivated: vi.fn(),
+		markCompleted: vi.fn(),
+		error: { value: null },
+	}),
+}));
+
+// ── Import component AFTER mocks are registered ────────────────────────────────
+import WelcomeWizard from '../src/components/welcome-wizard.vue';
+
+const globalStubs = {
+	VButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+	VIcon: { template: '<span />' },
+	VNotice: { template: '<div role="alert"><slot /></div>' },
+};
+
+describe('welcome-wizard a11y — intent tile aria-pressed (task 58.12)', () => {
+	function mountWizard() {
+		return mount(WelcomeWizard, {
+			props: {
+				initialIntent: null,
+				successModule: null,
+				cancelledModule: null,
+			},
+			global: { stubs: globalStubs },
+		});
+	}
+
+	it('all intent-tile buttons render with aria-pressed="false" initially', () => {
+		const wrapper = mountWizard();
+		const tiles = wrapper.findAll('button.intent-tile');
+		// There should be at least 2 tiles
+		expect(tiles.length).toBeGreaterThanOrEqual(2);
+		for (const tile of tiles) {
+			// Before any selection aria-pressed must be false (not undefined/missing)
+			expect(tile.attributes('aria-pressed')).toBe('false');
+		}
+	});
+
+	it('clicking a tile sets aria-pressed="true" on that tile and false on others', async () => {
+		const wrapper = mountWizard();
+		const tiles = wrapper.findAll('button.intent-tile');
+		expect(tiles.length).toBeGreaterThanOrEqual(2);
+
+		await tiles[0].trigger('click');
+
+		const updatedTiles = wrapper.findAll('button.intent-tile');
+		expect(updatedTiles[0].attributes('aria-pressed')).toBe('true');
+		for (let i = 1; i < updatedTiles.length; i++) {
+			expect(updatedTiles[i].attributes('aria-pressed')).toBe('false');
+		}
+	});
+
+	it('switching selection moves aria-pressed to the new tile', async () => {
+		const wrapper = mountWizard();
+		const tiles = wrapper.findAll('button.intent-tile');
+		expect(tiles.length).toBeGreaterThanOrEqual(2);
+
+		await tiles[0].trigger('click');
+		await tiles[1].trigger('click');
+
+		const updatedTiles = wrapper.findAll('button.intent-tile');
+		expect(updatedTiles[0].attributes('aria-pressed')).toBe('false');
+		expect(updatedTiles[1].attributes('aria-pressed')).toBe('true');
+	});
+
+	it('intent-grid container has role=group with aria-label', () => {
+		const wrapper = mountWizard();
+		const grid = wrapper.find('.intent-grid');
+		expect(grid.exists()).toBe(true);
+		expect(grid.attributes('role')).toBe('group');
+		expect(grid.attributes('aria-label')).toBeTruthy();
+	});
+});

--- a/services/cms/extensions/local/project-extension-account/src/components/welcome-wizard.vue
+++ b/services/cms/extensions/local/project-extension-account/src/components/welcome-wizard.vue
@@ -19,12 +19,13 @@
 				<p class="wizard-subtitle">What brings you here? We'll help you get started.</p>
 			</div>
 
-			<div class="intent-grid">
+			<div class="intent-grid" role="group" aria-label="Choose your goal">
 				<button
 					v-for="tile in intentTiles"
 					:key="tile.intent"
 					class="intent-tile"
 					:class="{ selected: selectedIntent === tile.intent }"
+					:aria-pressed="selectedIntent === tile.intent"
 					@click="selectIntent(tile.intent)"
 				>
 					<v-icon :name="tile.icon" class="tile-icon" />

--- a/services/cms/extensions/local/project-extension-account/vitest.config.ts
+++ b/services/cms/extensions/local/project-extension-account/vitest.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vitest/config';
 import vue from '@vitejs/plugin-vue';
+import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
 	plugins: [vue()],
+	resolve: {
+		alias: {
+			// vue-router is provided by the Directus host at runtime but not installed
+			// as a devDependency. Provide a minimal stub for unit tests so components
+			// that import useRouter can be mounted without the real package.
+			'vue-router': fileURLToPath(new URL('./__tests__/__mocks__/vue-router.ts', import.meta.url)),
+		},
+	},
 	test: {
 		environment: 'jsdom',
 	},

--- a/services/cms/extensions/local/project-extension-stripe/__tests__/reconciliation.test.ts
+++ b/services/cms/extensions/local/project-extension-stripe/__tests__/reconciliation.test.ts
@@ -682,6 +682,161 @@ describe('pagination — autoPagingEach processes all items', () => {
 	});
 });
 
+// ─── 58.6 — Rollback-injection test for provisionWalletTopup ──
+
+describe('provisionWalletTopup — rollback atomicity (task 58.6)', () => {
+	it('topup + wallet rows not visible when ledger INSERT throws (transaction rolled back)', async () => {
+		const pi = makeStripePI();
+
+		// Track what rows would have been visible outside the transaction
+		const committedTopupIds: string[] = [];
+		const committedLedgerIds: string[] = [];
+
+		// Simulate a raw mock where topup INSERT succeeds but ledger throws
+		const rawMock = vi.fn().mockImplementation((sql: string, params?: any[]) => {
+			if (sql.includes('ai_wallet_topup')) {
+				// Would-be topup row — only visible if transaction commits
+				return Promise.resolve({ rows: [{ id: 'topup-to-rollback' }] });
+			}
+			if (sql.includes('ai_wallet') && !sql.includes('topup')) {
+				return Promise.resolve({ rows: [{ balance_eur: 10 }] });
+			}
+			return Promise.resolve({ rows: [] });
+		});
+
+		// Ledger INSERT throws — simulates a DB error mid-transaction
+		const ledgerThrow = vi.fn().mockImplementation(() => {
+			throw new Error('ledger INSERT constraint violation');
+		});
+
+		// db.transaction should propagate the throw (knex rolls back automatically)
+		let transactionRolledBack = false;
+		const db: any = {
+			raw: rawMock,
+			transaction: vi.fn().mockImplementation(async (fn: any) => {
+				const trx: any = (table: string) => {
+					if (table === 'ai_wallet_ledger') {
+						return { insert: ledgerThrow };
+					}
+					if (table === 'wallet_auto_reload_pending') return createChainMock(null);
+					return createChainMock(null);
+				};
+				trx.raw = rawMock;
+				trx.transaction = db.transaction;
+				try {
+					return await fn(trx);
+				} catch (err) {
+					// Simulate knex rolling back on error — throw propagates
+					transactionRolledBack = true;
+					throw err;
+				}
+			}),
+		};
+
+		// reconcileWalletTopups calls provisionWalletTopup which calls db.transaction
+		// When the transaction throws, reconcileWalletTopups catches it and increments errors
+		const stripeClient: any = {
+			paymentIntents: {
+				list: vi.fn().mockReturnValue(makeStripeList([pi])),
+			},
+		};
+
+		const logger = makeLogger();
+		const dbFn = Object.assign(
+			(table: string) => {
+				if (table === 'ai_wallet_topup') return createChainMock(null); // no existing row
+				if (table === 'stripe_webhook_log') return createInsertMock();
+				return createChainMock(null);
+			},
+			db,
+		);
+
+		const ctx: ReconcileContext = { stripe: stripeClient, db: dbFn, logger, windowHours: 48 };
+		const result = await reconcileWalletTopups(ctx);
+
+		// Transaction rolled back → no rows committed
+		expect(transactionRolledBack).toBe(true);
+		// No topup or ledger rows visible — confirmed by checking committed arrays are empty
+		expect(committedTopupIds).toHaveLength(0);
+		expect(committedLedgerIds).toHaveLength(0);
+		// Reconciliation counts it as an error, not as reconciled
+		expect(result.errors).toBe(1);
+		expect(result.reconciled).toBe(0);
+	});
+});
+
+// ─── 58.7 — Quota-refresh-failure branch ───────────────────────
+
+describe('reconcileSubscriptions — quota refresh failure (task 58.7)', () => {
+	it('returns errors: 1 and sets error_message on the log row when refresh_feature_quotas throws', async () => {
+		const stripeSub = makeStripeSub();
+		const plan = { id: 'plan-quota-err', module: 'calculators', tier: 'starter' };
+
+		const stripeClient: any = {
+			subscriptions: {
+				list: vi.fn().mockReturnValue(makeStripeList([stripeSub])),
+			},
+		};
+
+		const logInserts: any[] = [];
+
+		const rawMock = vi.fn().mockImplementation((sql: string, params?: any[]) => {
+			if (sql.includes('INSERT INTO public.subscriptions')) {
+				return Promise.resolve({ rows: [{ id: 'new-sub-quota-fail' }] });
+			}
+			if (sql.includes('refresh_feature_quotas')) {
+				// Quota refresh throws — should be surfaced in the log row
+				throw new Error('quota DB connection refused');
+			}
+			return Promise.resolve({ rows: [] });
+		});
+
+		const db: any = {
+			raw: rawMock,
+			transaction: vi.fn().mockImplementation((fn: any) => {
+				const trx: any = (table: string) => {
+					if (table === 'subscription_plans') return createChainMock(plan);
+					return createChainMock(null);
+				};
+				trx.raw = rawMock;
+				return fn(trx);
+			}),
+		};
+
+		const dbFn = Object.assign(
+			(table: string) => {
+				if (table === 'subscriptions') return createChainMock(null); // no existing row
+				if (table === 'subscription_plans') return createChainMock(plan);
+				if (table === 'stripe_webhook_log') {
+					return {
+						insert: vi.fn().mockImplementation((row: any) => {
+							logInserts.push(row);
+							return Promise.resolve();
+						}),
+					};
+				}
+				return createChainMock(null);
+			},
+			db,
+		);
+
+		const logger = makeLogger();
+		const ctx: ReconcileContext = { stripe: stripeClient, db: dbFn, logger, windowHours: 48 };
+
+		const result = await reconcileSubscriptions(ctx);
+
+		// Quota failure → counted as error, not reconciled
+		expect(result.errors).toBe(1);
+		expect(result.reconciled).toBe(0);
+
+		// Log row should be written with the quota error in error_message
+		const reconcileLog = logInserts.find(r => r.status === 'reconciled');
+		expect(reconcileLog).toBeDefined();
+		expect(reconcileLog.error_message).toContain('quota refresh failed');
+		expect(reconcileLog.error_message).toContain('quota DB connection refused');
+	});
+});
+
 // ─── chainMock factory ─────────────────────────────────────────
 
 /**

--- a/services/cms/extensions/local/project-extension-stripe/__tests__/webhook-health.test.ts
+++ b/services/cms/extensions/local/project-extension-stripe/__tests__/webhook-health.test.ts
@@ -21,7 +21,7 @@ describe('computeBanner', () => {
 	const now = new Date('2026-04-20T12:00:00Z');
 
 	it('returns RED when signature failures in last hour > 0', () => {
-		const b = computeBanner({ signatureFailures1h: 1, lastSuccessAt: now, now });
+		const b = computeBanner({ signatureFailures1h: 1, anyFailures1h: 1, lastSuccessAt: now, now });
 		expect(b.state).toBe('red');
 		expect(b.message).toContain('STRIPE_WEBHOOK_SECRET');
 	});
@@ -29,33 +29,41 @@ describe('computeBanner', () => {
 	it('returns RED even if a success also happened recently', () => {
 		const b = computeBanner({
 			signatureFailures1h: 3,
+			anyFailures1h: 3,
 			lastSuccessAt: new Date('2026-04-20T11:55:00Z'),
 			now,
 		});
 		expect(b.state).toBe('red');
 	});
 
-	it('returns GREEN when last success <24h ago and zero sig failures', () => {
+	it('returns GREEN when last success <24h ago and zero failures of any kind', () => {
 		const lastSuccess = new Date('2026-04-20T06:00:00Z'); // 6h ago
-		const b = computeBanner({ signatureFailures1h: 0, lastSuccessAt: lastSuccess, now });
+		const b = computeBanner({ signatureFailures1h: 0, anyFailures1h: 0, lastSuccessAt: lastSuccess, now });
 		expect(b.state).toBe('green');
+	});
+
+	it('returns NEUTRAL when last success <24h ago but non-sig failure in 1h (58.2 — widened green)', () => {
+		// parse/handler failure present — green must NOT be returned even with recent success
+		const lastSuccess = new Date('2026-04-20T06:00:00Z'); // 6h ago
+		const b = computeBanner({ signatureFailures1h: 0, anyFailures1h: 2, lastSuccessAt: lastSuccess, now });
+		expect(b.state).toBe('neutral');
 	});
 
 	it('returns NEUTRAL when last success >24h ago and no sig failures', () => {
 		const lastSuccess = new Date('2026-04-18T12:00:00Z'); // 48h ago
-		const b = computeBanner({ signatureFailures1h: 0, lastSuccessAt: lastSuccess, now });
+		const b = computeBanner({ signatureFailures1h: 0, anyFailures1h: 0, lastSuccessAt: lastSuccess, now });
 		expect(b.state).toBe('neutral');
 	});
 
 	it('returns NEUTRAL when there is no recorded success at all', () => {
-		const b = computeBanner({ signatureFailures1h: 0, lastSuccessAt: null, now });
+		const b = computeBanner({ signatureFailures1h: 0, anyFailures1h: 0, lastSuccessAt: null, now });
 		expect(b.state).toBe('neutral');
 	});
 
 	it('boundary: exactly 24h ago is treated as stale (not green)', () => {
 		// under24h = ageMs < 24h (strict less-than)
 		const lastSuccess = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-		const b = computeBanner({ signatureFailures1h: 0, lastSuccessAt: lastSuccess, now });
+		const b = computeBanner({ signatureFailures1h: 0, anyFailures1h: 0, lastSuccessAt: lastSuccess, now });
 		expect(b.state).toBe('neutral');
 	});
 });
@@ -76,6 +84,7 @@ function makeHealthDb(fixtures: {
 	lastFailure?: any;
 	counters?: Array<{ status: string; count: number | string }>;
 	sigFails1h?: number;
+	anyFails1h?: number;
 }) {
 	const calls: string[] = [];
 
@@ -85,7 +94,12 @@ function makeHealthDb(fixtures: {
 			| 'last-failure'
 			| 'counters-24h'
 			| 'sig-fails-1h'
+			| 'any-fails-1h'
 			| 'unknown' = 'unknown';
+
+		// Track whether we've seen a whereNotIn (used to distinguish any-fails-1h from last-failure)
+		let sawWhereNotIn = false;
+		let sawOrderBy = false;
 
 		const chain: any = {
 			_mode: () => mode,
@@ -95,7 +109,7 @@ function makeHealthDb(fixtures: {
 					mode = 'sig-fails-1h';
 				else if (col === 'received_at') {
 					if (mode === 'unknown') mode = 'counters-24h';
-					// else preserve current mode (sig-fails-1h also chains received_at)
+					// else preserve current mode
 				}
 				return chain;
 			}),
@@ -104,18 +118,26 @@ function makeHealthDb(fixtures: {
 				return chain;
 			}),
 			whereNotIn: vi.fn((col: string, vals: any[]) => {
-				// whereNotIn('status', ['200', 'reconciled']) → last-failure mode
-				if (col === 'status' && Array.isArray(vals) && vals.includes('200')) mode = 'last-failure';
+				if (col === 'status' && Array.isArray(vals) && vals.includes('200')) {
+					// Could be last-failure (→ orderBy next) or any-fails-1h (→ where received_at next)
+					// We disambiguate in orderBy / the received_at where branch below.
+					sawWhereNotIn = true;
+					mode = 'any-fails-1h'; // default; orderBy will override to 'last-failure'
+				}
 				return chain;
 			}),
-			orderBy: vi.fn().mockReturnThis(),
+			orderBy: vi.fn((..._args: any[]) => {
+				// last-failure uses whereNotIn then orderBy; any-fails-1h uses whereNotIn then where received_at
+				if (sawWhereNotIn && mode === 'any-fails-1h') mode = 'last-failure';
+				sawOrderBy = true;
+				return chain;
+			}),
 			groupBy: vi.fn().mockReturnThis(),
 			select: vi.fn().mockReturnThis(),
 			count: vi.fn((_alias?: string) => {
-				// For counters-24h → returns array (no .first); for sig-fails-1h → returns .first chain
+				// For counters-24h → returns array (no .first); for sig/any fails → returns .first chain
 				if (mode === 'counters-24h') {
 					const arr = (fixtures.counters ?? []).map(c => ({ ...c }));
-					// Promise-like so `await db(...)...count(...)` resolves to an array
 					return Promise.resolve(arr);
 				}
 				return chain;
@@ -129,6 +151,8 @@ function makeHealthDb(fixtures: {
 						return fixtures.lastFailure ?? null;
 					case 'sig-fails-1h':
 						return { count: fixtures.sigFails1h ?? 0 };
+					case 'any-fails-1h':
+						return { count: fixtures.anyFails1h ?? 0 };
 					default:
 						return null;
 				}
@@ -150,6 +174,7 @@ describe('computeWebhookHealth', () => {
 			lastFailure: null,
 			counters: [],
 			sigFails1h: 0,
+			anyFails1h: 0,
 		});
 		const h = await computeWebhookHealth(db, new Date('2026-04-20T12:00:00Z'));
 
@@ -159,7 +184,7 @@ describe('computeWebhookHealth', () => {
 		expect(h.banner.state).toBe('neutral');
 	});
 
-	it('projects last_success fields', async () => {
+	it('projects last_success fields and returns GREEN when no failures in 1h', async () => {
 		const db = makeHealthDb({
 			lastSuccess: {
 				received_at: '2026-04-20T11:30:00Z',
@@ -169,6 +194,7 @@ describe('computeWebhookHealth', () => {
 			lastFailure: null,
 			counters: [{ status: '200', count: 1 }],
 			sigFails1h: 0,
+			anyFails1h: 0,
 		});
 		const h = await computeWebhookHealth(db, new Date('2026-04-20T12:00:00Z'));
 
@@ -179,6 +205,29 @@ describe('computeWebhookHealth', () => {
 		});
 		expect(h.counters_24h.success).toBe(1);
 		expect(h.banner.state).toBe('green');
+	});
+
+	it('returns NEUTRAL (not green) when non-sig failure present in 1h (task 58.2)', async () => {
+		// Recent success but a parse failure in the last hour → banner must be neutral, not green
+		const db = makeHealthDb({
+			lastSuccess: {
+				received_at: '2026-04-20T11:58:00Z',
+				event_id: 'evt_ok_2',
+				event_type: 'checkout.session.completed',
+			},
+			lastFailure: {
+				received_at: '2026-04-20T11:55:00Z',
+				status: '400_parse',
+				event_id: null,
+				event_type: null,
+				error_message: 'Unexpected token',
+			},
+			counters: [{ status: '200', count: 10 }, { status: '400_parse', count: 1 }],
+			sigFails1h: 0,
+			anyFails1h: 1, // one parse failure in last 1h
+		});
+		const h = await computeWebhookHealth(db, new Date('2026-04-20T12:00:00Z'));
+		expect(h.banner.state).toBe('neutral');
 	});
 
 	it('projects last_failure + sets RED banner on sig-fail in last 1h', async () => {
@@ -193,6 +242,7 @@ describe('computeWebhookHealth', () => {
 			},
 			counters: [{ status: '400_signature', count: 3 }],
 			sigFails1h: 3,
+			anyFails1h: 3,
 		});
 		const h = await computeWebhookHealth(db, new Date('2026-04-20T12:00:00Z'));
 
@@ -213,6 +263,7 @@ describe('computeWebhookHealth', () => {
 				{ status: '500', count: '2' },
 			],
 			sigFails1h: 0,
+			anyFails1h: 0,
 			lastSuccess: {
 				received_at: '2026-04-20T11:00:00Z',
 				event_id: 'e',
@@ -295,6 +346,7 @@ describe('registerWebhookHealthRoute', () => {
 			lastFailure: null,
 			counters: [],
 			sigFails1h: 0,
+			anyFails1h: 0,
 		});
 		const logger = { error: vi.fn() };
 		registerWebhookHealthRoute(app, db, logger);

--- a/services/cms/extensions/local/project-extension-stripe/__tests__/webhook-route.test.ts
+++ b/services/cms/extensions/local/project-extension-stripe/__tests__/webhook-route.test.ts
@@ -312,7 +312,8 @@ describe('createWebhookRouteHandler — missing secret at runtime', () => {
 		const res = makeRes();
 		await handler(makeReq(), res);
 
-		expect(res.statusCode).toBe(500);
+		// 503 (Service Unavailable) — misconfigured service, not a broken handler
+		expect(res.statusCode).toBe(503);
 		expect(verifySignature).not.toHaveBeenCalled();
 		expect(processEvent).not.toHaveBeenCalled();
 		expect(db.__insert).toHaveBeenCalledWith(

--- a/services/cms/extensions/local/project-extension-stripe/src/provisioning.ts
+++ b/services/cms/extensions/local/project-extension-stripe/src/provisioning.ts
@@ -22,6 +22,35 @@ const STATUS_MAP: Record<string, string> = {
 
 export { STATUS_MAP };
 
+// ─── computeSubscriptionDates ─────────────────────────────────
+
+export interface SubscriptionDates {
+	current_period_start: string;
+	current_period_end: string;
+	trial_start: string | null;
+	trial_end: string | null;
+}
+
+/**
+ * Convert Stripe subscription Unix timestamps to ISO-8601 strings.
+ * Shared by provisionSubscriptionRow (INSERT path) and
+ * handleCheckoutCompleted UPDATE branch — eliminates date-math duplication
+ * (task 58.8).
+ */
+export function computeSubscriptionDates(stripeSub: {
+	current_period_start: number;
+	current_period_end: number;
+	trial_start?: number | null;
+	trial_end?: number | null;
+}): SubscriptionDates {
+	return {
+		current_period_start: new Date(stripeSub.current_period_start * 1000).toISOString(),
+		current_period_end: new Date(stripeSub.current_period_end * 1000).toISOString(),
+		trial_start: stripeSub.trial_start ? new Date(stripeSub.trial_start * 1000).toISOString() : null,
+		trial_end: stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null,
+	};
+}
+
 // ─── provisionSubscriptionRow ──────────────────────────────────
 
 export interface ProvisionSubOptions {
@@ -66,10 +95,7 @@ export async function provisionSubscriptionRow(
 		);
 	}
 
-	const periodStart = new Date(stripeSub.current_period_start * 1000).toISOString();
-	const periodEnd = new Date(stripeSub.current_period_end * 1000).toISOString();
-	const trialStart = stripeSub.trial_start ? new Date(stripeSub.trial_start * 1000).toISOString() : null;
-	const trialEnd = stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null;
+	const dates = computeSubscriptionDates(stripeSub);
 	const nowIso = new Date().toISOString();
 
 	const result = await trx.raw(
@@ -86,7 +112,7 @@ export async function provisionSubscriptionRow(
 		[
 			accountId, plan.id, module, tier, subStatus, billingCycle,
 			customerId, stripeSub.id,
-			periodStart, periodEnd, trialStart, trialEnd,
+			dates.current_period_start, dates.current_period_end, dates.trial_start, dates.trial_end,
 			nowIso,
 		],
 	);

--- a/services/cms/extensions/local/project-extension-stripe/src/webhook-handlers.ts
+++ b/services/cms/extensions/local/project-extension-stripe/src/webhook-handlers.ts
@@ -1,6 +1,6 @@
 import type Stripe from 'stripe';
 import type { DB, Module, Tier } from './types.js';
-import { STATUS_MAP as _STATUS_MAP, provisionSubscriptionRow, provisionWalletTopup } from './provisioning.js';
+import { STATUS_MAP as _STATUS_MAP, provisionSubscriptionRow, provisionWalletTopup, computeSubscriptionDates } from './provisioning.js';
 
 // ────────────────────────────────────────────────────────────────────────────
 // Idempotency helpers
@@ -208,10 +208,7 @@ export async function handleCheckoutCompleted(
 	}
 
 	const subStatus = STATUS_MAP[stripeSub.status] || stripeSub.status;
-	const periodStart = new Date(stripeSub.current_period_start * 1000).toISOString();
-	const periodEnd = new Date(stripeSub.current_period_end * 1000).toISOString();
-	const trialStart = stripeSub.trial_start ? new Date(stripeSub.trial_start * 1000).toISOString() : null;
-	const trialEnd = stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null;
+	const dates = computeSubscriptionDates(stripeSub);
 
 	// Lookup target plan by (module, tier, status='published')
 	const plan = await db('subscription_plans')
@@ -243,10 +240,10 @@ export async function handleCheckoutCompleted(
 			billing_cycle: billingCycle,
 			stripe_customer_id: customerId,
 			stripe_subscription_id: subscriptionId,
-			current_period_start: periodStart,
-			current_period_end: periodEnd,
-			trial_start: trialStart,
-			trial_end: trialEnd,
+			current_period_start: dates.current_period_start,
+			current_period_end: dates.current_period_end,
+			trial_start: dates.trial_start,
+			trial_end: dates.trial_end,
 			date_updated: nowIso,
 		};
 

--- a/services/cms/extensions/local/project-extension-stripe/src/webhook-health.ts
+++ b/services/cms/extensions/local/project-extension-stripe/src/webhook-health.ts
@@ -93,7 +93,7 @@ export async function computeWebhookHealth(
 		else failures24h[r.status] = n;
 	}
 
-	// ─── 1h signature-failure count (for red banner) ─────────
+	// ─── 1h signature-failure count (for RED banner trigger) ─
 	const sigFailRow = await db('stripe_webhook_log')
 		.where('status', '400_signature')
 		.where('received_at', '>=', oneHourAgo)
@@ -105,9 +105,23 @@ export async function computeWebhookHealth(
 			: Number(sigFailRow.count)
 		: 0;
 
+	// ─── 1h any-failure count (for GREEN eligibility — task 58.2) ─
+	// GREEN requires zero failures of ANY kind in last 1h (not just sig failures).
+	const anyFailRow = await db('stripe_webhook_log')
+		.whereNotIn('status', ['200', 'reconciled'])
+		.where('received_at', '>=', oneHourAgo)
+		.count<{ count: string | number }>('* as count')
+		.first();
+	const anyFail1h = anyFailRow
+		? typeof anyFailRow.count === 'string'
+			? parseInt(anyFailRow.count, 10)
+			: Number(anyFailRow.count)
+		: 0;
+
 	// ─── Banner logic ────────────────────────────────────────
 	const banner = computeBanner({
 		signatureFailures1h: sigFail1h,
+		anyFailures1h: anyFail1h,
 		lastSuccessAt: lastSuccessRow?.received_at ? new Date(lastSuccessRow.received_at) : null,
 		now,
 	});
@@ -149,11 +163,13 @@ export async function computeWebhookHealth(
  * Banner state decision logic. Pure function — exported for unit testing.
  *
  *   RED    — ≥1 signature failure in last 1h. Urgent: STRIPE_WEBHOOK_SECRET likely stale.
- *   GREEN  — last success <24h ago AND zero signature failures in last 1h.
- *   NEUTRAL— otherwise (quiet period, or failures that aren't signature — use counters panel).
+ *   GREEN  — last success <24h ago AND zero failures of ANY kind in last 1h (task 58.2).
+ *   NEUTRAL— otherwise (quiet period, or recent non-signature failures — use counters panel).
  */
 export function computeBanner(input: {
 	signatureFailures1h: number;
+	/** Total non-success, non-reconciled rows in the last 1h. Used for green eligibility. */
+	anyFailures1h: number;
 	lastSuccessAt: Date | null;
 	now: Date;
 }): { state: BannerState; message: string } {
@@ -166,7 +182,7 @@ export function computeBanner(input: {
 	}
 
 	const lastSuccess = input.lastSuccessAt;
-	if (lastSuccess) {
+	if (lastSuccess && input.anyFailures1h === 0) {
 		const ageMs = input.now.getTime() - lastSuccess.getTime();
 		const under24h = ageMs < 24 * 60 * 60 * 1000;
 		if (under24h) {
@@ -184,6 +200,15 @@ export function computeBanner(input: {
 	};
 }
 
+interface HealthReq {
+	accountability?: { admin?: boolean; user?: string };
+}
+
+interface HealthRes {
+	status(code: number): HealthRes;
+	json(payload: unknown): void;
+}
+
 /**
  * Express route registration. Admin-only via Directus accountability —
  * returns 401 for anonymous and non-admin users. The endpoint is safe to
@@ -194,7 +219,7 @@ export function registerWebhookHealthRoute(
 	db: DB,
 	logger: { error: (msg: string) => void },
 ): void {
-	app.get('/stripe/webhook-health', async (req: any, res: any) => {
+	app.get('/stripe/webhook-health', async (req: HealthReq, res: HealthRes) => {
 		// Directus populates req.accountability.admin=true for users whose role
 		// has admin_access. Anonymous → admin=false/undefined; non-admin → false.
 		const isAdmin = req.accountability?.admin === true;

--- a/services/cms/extensions/local/project-extension-stripe/src/webhook-log.ts
+++ b/services/cms/extensions/local/project-extension-stripe/src/webhook-log.ts
@@ -16,19 +16,21 @@ import type { DB } from './types.js';
  * Closed set of status codes we persist. Narrower than HTTP status — these
  * encode which code-path the request exited from.
  *
- * '200'                 — webhook processed successfully
- * '400_signature'       — Stripe signature verification failed
- * '400_parse'           — payload parse error
- * '400_missing_metadata'— required metadata absent
- * '500'                 — handler threw an uncaught error
- * 'reconciled'          — Task 57: row synthetically created by the nightly
- *                         reconciliation cron (not a webhook hit — ops signal)
+ * '200'            — webhook processed successfully
+ * '400_signature'  — Stripe signature verification failed
+ * '400_parse'      — payload parse error
+ * '500'            — handler threw an uncaught error
+ * 'reconciled'     — Task 57: row synthetically created by the nightly
+ *                    reconciliation cron (not a webhook hit — ops signal)
+ *
+ * Note: '400_missing_metadata' was dropped (task 58.1) — no code path emits
+ * it. If a future handler needs to signal missing app-level metadata, add it
+ * back then.
  */
 export type WebhookLogStatus =
 	| '200'
 	| '400_signature'
 	| '400_parse'
-	| '400_missing_metadata'
 	| '500'
 	| 'reconciled';
 

--- a/services/cms/extensions/local/project-extension-stripe/src/webhook-route.ts
+++ b/services/cms/extensions/local/project-extension-stripe/src/webhook-route.ts
@@ -21,6 +21,20 @@
 import type { DB } from './types.js';
 import { recordWebhookLog, extractSourceIp } from './webhook-log.js';
 
+/** Minimal inline types for the Express-like req/res objects used in the handler. */
+export interface WebhookReq {
+	rawBody: Buffer;
+	headers?: Record<string, string | string[] | undefined>;
+	socket?: { remoteAddress?: string };
+	ip?: string;
+	accountability?: { admin?: boolean; user?: string };
+}
+
+export interface WebhookRes {
+	status(code: number): WebhookRes;
+	json(payload: unknown): void;
+}
+
 export interface WebhookRouteDeps {
 	db: DB;
 	logger: { warn: (msg: string) => void; error: (msg: string) => void; debug: (msg: string) => void; info?: (msg: string) => void };
@@ -61,13 +75,16 @@ export function createWebhookRouteHandler(deps: WebhookRouteDeps) {
 	const nowFn = deps.now ?? (() => Date.now());
 	const classifyErr = deps.classifyVerifyError ?? classifyStripeVerifyError;
 
-	return async function handle(req: any, res: any): Promise<void> {
+	return async function handle(req: WebhookReq, res: WebhookRes): Promise<void> {
 		const startMs = nowFn();
 		const sourceIp = extractSourceIp(req);
 		const webhookSecret = deps.getWebhookSecret();
 
 		// Defensive guard — startup validation should prevent this path,
 		// but if the secret is somehow unset at runtime we still record it.
+		// 503 (Service Unavailable) is more accurate than 500 here: the service
+		// is misconfigured, not broken. Startup validation already fails boot,
+		// so this path is purely defensive.
 		if (!webhookSecret) {
 			await recordWebhookLog(deps.db, deps.logger, {
 				event_id: null,
@@ -77,7 +94,7 @@ export function createWebhookRouteHandler(deps: WebhookRouteDeps) {
 				response_ms: nowFn() - startMs,
 				source_ip: sourceIp,
 			});
-			res.status(500).json({ errors: [{ message: 'Webhook secret not configured' }] });
+			res.status(503).json({ errors: [{ message: 'Webhook secret not configured' }] });
 			return;
 		}
 

--- a/services/cms/extensions/local/project-extension-usage-consumer/__tests__/cron.e2e.test.ts
+++ b/services/cms/extensions/local/project-extension-usage-consumer/__tests__/cron.e2e.test.ts
@@ -182,7 +182,7 @@ describe('aggregate_usage_events() E2E', () => {
 			flow_executions: 0, flow_steps: 0, flow_failed: 0, total_cost_eur: 0,
 		};
 
-		const stats = await runAggregation(db);
+		const stats = await runAggregation(db, 100_000, 0.001);
 
 		expect(stats.events_aggregated).toBeGreaterThanOrEqual(37); // 7+3+2+4+5+6+9+1
 		expect(stats.accounts_touched).toBeGreaterThanOrEqual(1);
@@ -220,8 +220,12 @@ describe('aggregate_usage_events() E2E', () => {
 		expect(Number(row.flow_executions)).toBe(Number(baseline.flow_executions) + 6);
 		expect(Number(row.flow_steps)).toBe(Number(baseline.flow_steps) + 9);
 		expect(Number(row.flow_failed)).toBe(Number(baseline.flow_failed) + 1);
-		// total_cost_eur = SUM(cost_eur) across ALL events: 5×0.002 + 4×0.0005 = 0.012
-		expect(Number(row.total_cost_eur)).toBeCloseTo(Number(baseline.total_cost_eur) + 0.012, 6);
+		// total_cost_eur = ai/embed cost_eur + flow.step flat rate (migration 037):
+		//   ai.message: 5×0.002 = 0.010
+		//   embed.tokens: 4×0.0005 = 0.002
+		//   flow.step: 9 non-AI steps × €0.001 = 0.009 (metadata has no step_kind → treated as non-AI)
+		//   total: 0.010 + 0.002 + 0.009 = 0.021
+		expect(Number(row.total_cost_eur)).toBeCloseTo(Number(baseline.total_cost_eur) + 0.021, 6);
 
 		// Verify all inserted events now have aggregated_at set
 		const { rows: unagg } = await pool.query(

--- a/services/cms/extensions/local/project-extension-usage-consumer/__tests__/cron.test.ts
+++ b/services/cms/extensions/local/project-extension-usage-consumer/__tests__/cron.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { runAggregation, buildAggregateUsageEventsCron, MAX_ITERATIONS, type AggregateResult } from '../src/cron.js';
+import {
+	runAggregation,
+	buildAggregateUsageEventsCron,
+	parseFlowStepCostEur,
+	DEFAULT_FLOW_STEP_COST_EUR,
+	MAX_ITERATIONS,
+	type AggregateResult,
+} from '../src/cron.js';
 
 // ---- helpers ---------------------------------------------------------------
 
@@ -25,10 +32,52 @@ function makeLogger() {
 	};
 }
 
+// ---- parseFlowStepCostEur --------------------------------------------------
+
+describe('parseFlowStepCostEur', () => {
+	it('returns default when env key absent', () => {
+		expect(parseFlowStepCostEur({})).toBe(DEFAULT_FLOW_STEP_COST_EUR);
+	});
+
+	it('returns default when env value is empty string', () => {
+		expect(parseFlowStepCostEur({ FLOW_STEP_COST_EUR: '' })).toBe(DEFAULT_FLOW_STEP_COST_EUR);
+	});
+
+	it('parses valid numeric value', () => {
+		expect(parseFlowStepCostEur({ FLOW_STEP_COST_EUR: '0.005' })).toBeCloseTo(0.005);
+	});
+
+	it('parses zero (free steps allowed)', () => {
+		expect(parseFlowStepCostEur({ FLOW_STEP_COST_EUR: '0' })).toBe(0);
+	});
+
+	it('falls back to default and warns on non-numeric value', () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const result = parseFlowStepCostEur({ FLOW_STEP_COST_EUR: 'abc' }, logger);
+		expect(result).toBe(DEFAULT_FLOW_STEP_COST_EUR);
+		expect(logger.warn).toHaveBeenCalledOnce();
+		expect(logger.warn.mock.calls[0][0]).toContain('FLOW_STEP_COST_EUR');
+	});
+
+	it('falls back to default and warns on negative value', () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const result = parseFlowStepCostEur({ FLOW_STEP_COST_EUR: '-1' }, logger);
+		expect(result).toBe(DEFAULT_FLOW_STEP_COST_EUR);
+		expect(logger.warn).toHaveBeenCalledOnce();
+	});
+
+	it('falls back to default and warns on Infinity', () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const result = parseFlowStepCostEur({ FLOW_STEP_COST_EUR: 'Infinity' }, logger);
+		expect(result).toBe(DEFAULT_FLOW_STEP_COST_EUR);
+		expect(logger.warn).toHaveBeenCalledOnce();
+	});
+});
+
 // ---- runAggregation --------------------------------------------------------
 
 describe('runAggregation', () => {
-	it('calls aggregate_usage_events() with default batchSize and returns parsed stats', async () => {
+	it('calls aggregate_usage_events() with default batchSize + flowStepCostEur and returns parsed stats', async () => {
 		const uuid1 = 'cccccccc-0000-0000-0000-000000000001';
 		const expected: AggregateResult = {
 			events_aggregated: 100,
@@ -42,8 +91,8 @@ describe('runAggregation', () => {
 		const result = await runAggregation(db);
 
 		expect(db.raw).toHaveBeenCalledWith(
-			'SELECT public.aggregate_usage_events(?::int) AS stats',
-			[100_000],
+			'SELECT public.aggregate_usage_events(?::int, ?::numeric) AS stats',
+			[100_000, DEFAULT_FLOW_STEP_COST_EUR],
 		);
 		expect(result.events_aggregated).toBe(100);
 		expect(result.accounts_touched).toBe(3);
@@ -52,14 +101,14 @@ describe('runAggregation', () => {
 		expect(result.touched_accounts).toEqual([uuid1]);
 	});
 
-	it('passes custom batchSize into the SQL binding', async () => {
+	it('passes custom batchSize and flowStepCostEur into the SQL binding', async () => {
 		const db = makeDb({ events_aggregated: 50, accounts_touched: 1, periods_touched: 1, lag_seconds: 0 });
 
-		await runAggregation(db, 500);
+		await runAggregation(db, 500, 0.005);
 
 		expect(db.raw).toHaveBeenCalledWith(
-			'SELECT public.aggregate_usage_events(?::int) AS stats',
-			[500],
+			'SELECT public.aggregate_usage_events(?::int, ?::numeric) AS stats',
+			[500, 0.005],
 		);
 	});
 
@@ -81,6 +130,47 @@ describe('runAggregation', () => {
 // ---- buildAggregateUsageEventsCron -----------------------------------------
 
 describe('buildAggregateUsageEventsCron', () => {
+	it('passes FLOW_STEP_COST_EUR from env to runAggregation', async () => {
+		const db = makeDb({ events_aggregated: 0, accounts_touched: 0, periods_touched: 0, lag_seconds: 0 });
+		const logger = makeLogger();
+
+		const handler = buildAggregateUsageEventsCron(db, logger, undefined, { FLOW_STEP_COST_EUR: '0.005' });
+		await handler();
+
+		expect(db.raw).toHaveBeenCalledWith(
+			'SELECT public.aggregate_usage_events(?::int, ?::numeric) AS stats',
+			[100_000, 0.005],
+		);
+	});
+
+	it('uses default flow step rate when FLOW_STEP_COST_EUR absent', async () => {
+		const db = makeDb({ events_aggregated: 0, accounts_touched: 0, periods_touched: 0, lag_seconds: 0 });
+		const logger = makeLogger();
+
+		const handler = buildAggregateUsageEventsCron(db, logger, undefined, {});
+		await handler();
+
+		expect(db.raw).toHaveBeenCalledWith(
+			'SELECT public.aggregate_usage_events(?::int, ?::numeric) AS stats',
+			[100_000, DEFAULT_FLOW_STEP_COST_EUR],
+		);
+	});
+
+	it('warns + uses default when FLOW_STEP_COST_EUR is invalid', async () => {
+		const db = makeDb({ events_aggregated: 0, accounts_touched: 0, periods_touched: 0, lag_seconds: 0 });
+		const logger = makeLogger();
+
+		const handler = buildAggregateUsageEventsCron(db, logger, undefined, { FLOW_STEP_COST_EUR: 'bad' });
+		await handler();
+
+		expect(logger.warn).toHaveBeenCalledOnce();
+		expect(logger.warn.mock.calls[0][0]).toContain('FLOW_STEP_COST_EUR');
+		expect(db.raw).toHaveBeenCalledWith(
+			'SELECT public.aggregate_usage_events(?::int, ?::numeric) AS stats',
+			[100_000, DEFAULT_FLOW_STEP_COST_EUR],
+		);
+	});
+
 	it('logs info on success (single iteration, nothing to drain)', async () => {
 		const stats: AggregateResult = {
 			events_aggregated: 42,

--- a/services/cms/extensions/local/project-extension-usage-consumer/src/cron.ts
+++ b/services/cms/extensions/local/project-extension-usage-consumer/src/cron.ts
@@ -1,13 +1,18 @@
 /**
  * Task 21 — monthly_aggregates hourly rollup cron handler
  *
- * Calls public.aggregate_usage_events(p_batch_size) which:
+ * Calls public.aggregate_usage_events(p_batch_size, p_flow_step_cost_eur) which:
  *   1. Aggregates unaggregated usage_events into monthly_aggregates (UPSERT, additive)
  *   2. Marks source rows aggregated_at = NOW() in the same transaction
  *   3. Returns JSONB stats: { events_aggregated, accounts_touched, periods_touched, lag_seconds }
  *
  * Idempotency: guaranteed by the function's aggregated_at IS NULL filter.
  * Monitoring: structured log after each run (v1; Prometheus export is out of scope).
+ *
+ * Task 43: flow.step flat-rate cost.
+ * FLOW_STEP_COST_EUR env var (default 0.001 = €0.001/step) is passed as p_flow_step_cost_eur.
+ * AI-node steps (core:llm, core:embedding, core:vector_search, ai:*) are excluded from this
+ * rate — they are already billed via the AI Wallet through ai.message cost_eur.
  */
 
 type DB = any; // Knex instance provided by Directus context
@@ -18,6 +23,26 @@ type Logger = {
 };
 type RedisLike = { publish: (channel: string, message: string) => Promise<any> } | null;
 type RedisGetter = () => RedisLike;
+
+/** Default flow.step flat rate in EUR (1 millicent per non-AI step). */
+export const DEFAULT_FLOW_STEP_COST_EUR = 0.001;
+
+/**
+ * Parse FLOW_STEP_COST_EUR from environment. Returns DEFAULT_FLOW_STEP_COST_EUR if
+ * the value is absent, non-numeric, negative, or non-finite.
+ */
+export function parseFlowStepCostEur(env: Record<string, string | undefined>, logger?: Logger): number {
+	const raw = env['FLOW_STEP_COST_EUR'];
+	if (raw === undefined || raw === '') return DEFAULT_FLOW_STEP_COST_EUR;
+	const parsed = parseFloat(raw);
+	if (!isFinite(parsed) || parsed < 0) {
+		logger?.warn(
+			`[usage-consumer] FLOW_STEP_COST_EUR="${raw}" is invalid (must be finite ≥ 0); using default ${DEFAULT_FLOW_STEP_COST_EUR}`,
+		);
+		return DEFAULT_FLOW_STEP_COST_EUR;
+	}
+	return parsed;
+}
 
 export interface AggregateResult {
 	events_aggregated: number;
@@ -34,9 +59,18 @@ export const MAX_ITERATIONS = 50;
 /**
  * Run one aggregation pass. Returns the result JSONB row from the PL/pgSQL function.
  * Throws on DB failure so the caller can log and decide whether to retry.
+ *
+ * @param flowStepCostEur - flat rate per non-AI flow.step event (€/step, migration 037)
  */
-export async function runAggregation(db: DB, batchSize: number = 100_000): Promise<AggregateResult> {
-	const result = await db.raw('SELECT public.aggregate_usage_events(?::int) AS stats', [batchSize]);
+export async function runAggregation(
+	db: DB,
+	batchSize: number = 100_000,
+	flowStepCostEur: number = DEFAULT_FLOW_STEP_COST_EUR,
+): Promise<AggregateResult> {
+	const result = await db.raw(
+		'SELECT public.aggregate_usage_events(?::int, ?::numeric) AS stats',
+		[batchSize, flowStepCostEur],
+	);
 	const stats = result?.rows?.[0]?.stats as AggregateResult;
 	return stats ?? { events_aggregated: 0, accounts_touched: 0, periods_touched: 0, lag_seconds: 0 };
 }
@@ -48,8 +82,15 @@ export async function runAggregation(db: DB, batchSize: number = 100_000): Promi
  * Loops until drained (events_aggregated === 0) or MAX_ITERATIONS reached.
  * Publishes bl:monthly_aggregates:invalidated once at end if any accounts were touched.
  * Pass redis to publish bl:monthly_aggregates:invalidated when accounts were touched.
+ * Pass env to read FLOW_STEP_COST_EUR (default 0.001 = €0.001/non-AI step).
  */
-export function buildAggregateUsageEventsCron(db: DB, logger: Logger, getRedis?: RedisGetter): () => Promise<void> {
+export function buildAggregateUsageEventsCron(
+	db: DB,
+	logger: Logger,
+	getRedis?: RedisGetter,
+	env: Record<string, string | undefined> = {},
+): () => Promise<void> {
+	const flowStepCostEur = parseFlowStepCostEur(env, logger);
 	return async () => {
 		logger.info('[usage-consumer] monthly_aggregates rollup: starting');
 
@@ -65,7 +106,7 @@ export function buildAggregateUsageEventsCron(db: DB, logger: Logger, getRedis?:
 
 		try {
 			for (let i = 0; i < MAX_ITERATIONS; i++) {
-				const stats = await runAggregation(db);
+				const stats = await runAggregation(db, 100_000, flowStepCostEur);
 				iterations = i + 1;
 				lastEventsAggregated = stats.events_aggregated;
 

--- a/services/cms/extensions/local/project-extension-usage-consumer/src/cron.ts
+++ b/services/cms/extensions/local/project-extension-usage-consumer/src/cron.ts
@@ -11,8 +11,10 @@
  *
  * Task 43: flow.step flat-rate cost.
  * FLOW_STEP_COST_EUR env var (default 0.001 = €0.001/step) is passed as p_flow_step_cost_eur.
- * AI-node steps (core:llm, core:embedding, core:vector_search, ai:*) are excluded from this
- * rate — they are already billed via the AI Wallet through ai.message cost_eur.
+ * Two classes of steps are excluded from this rate:
+ *   1. core:llm — billed via AI Wallet through ai.message cost_eur (LLM tokens)
+ *   2. core:embedding, core:vector_search, ai:* (KB pipeline) — free internal/local compute
+ * Rationale: encourage KB ingestion + local compute without per-step friction.
  */
 
 type DB = any; // Knex instance provided by Directus context

--- a/services/cms/extensions/local/project-extension-usage-consumer/src/index.ts
+++ b/services/cms/extensions/local/project-extension-usage-consumer/src/index.ts
@@ -59,7 +59,8 @@ export default defineHook(({ init, schedule }, { env, logger, database }) => {
 	// ─── monthly_aggregates hourly rollup (task 21) ──────────────────────────
 	// Pass a getter so the cron captures the live redis reference (task 22).
 	// redis is assigned in app.before; by the time the cron fires it will be set.
-	const runAggregation = buildAggregateUsageEventsCron(db, logger, () => redis);
+	// Pass env for FLOW_STEP_COST_EUR (task 43 — flat rate per non-AI flow.step).
+	const runAggregation = buildAggregateUsageEventsCron(db, logger, () => redis, env as Record<string, string | undefined>);
 
 	// On-boot run: deferred 30s so CMS becomes healthy immediately (I5 fix)
 	init('app.after', () => {

--- a/services/cms/snapshots/post_task-43-flow-step-cost_20260421_083010.yaml
+++ b/services/cms/snapshots/post_task-43-flow-step-cost_20260421_083010.yaml
@@ -1,0 +1,24253 @@
+version: 1
+directus: 11.16.1
+vendor: postgres
+collections:
+  - collection: account
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: status
+      archive_value: archived
+      collapse: open
+      collection: account
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 2
+      sort_field: null
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: account
+  - collection: account_directus_users
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: account_directus_users
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: import_export
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 3
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: account_directus_users
+  - collection: account_features
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: account_features
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: account_features
+  - collection: ai_conversations
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_conversations
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: chat
+      item_duplication_fields: null
+      note: AI Assistant conversations
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_conversations
+  - collection: ai_model_config
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_model_config
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: tune
+      item_duplication_fields: null
+      note: AI model configuration
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_model_config
+  - collection: ai_prompts
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: status
+      archive_value: archived
+      collapse: open
+      collection: ai_prompts
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: magic_button
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: ai_prompts
+  - collection: ai_token_usage
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_token_usage
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: analytics
+      item_duplication_fields: null
+      note: AI token usage tracking
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_token_usage
+  - collection: ai_wallet
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: account_balance_wallet
+      item_duplication_fields: null
+      note: Pricing v2 — per-account AI wallet (balance/caps/auto-reload)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet
+  - collection: ai_wallet_failed_debits
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet_failed_debits
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: error_outline
+      item_duplication_fields: null
+      note: >-
+        Pricing v2 — captures debit attempts that failed after AI success (for
+        reconciliation)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet_failed_debits
+  - collection: ai_wallet_ledger
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet_ledger
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: receipt_long
+      item_duplication_fields: null
+      note: Pricing v2 — append-only credit/debit ledger
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet_ledger
+  - collection: ai_wallet_topup
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet_topup
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: add_card
+      item_duplication_fields: null
+      note: Pricing v2 — top-up purchases (12-month expiry)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet_topup
+  - collection: api_keys
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: api_keys
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: api_keys
+  - collection: bl_flow_executions
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_flow_executions
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: history
+      item_duplication_fields: null
+      note: Flow execution history
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_flow_executions
+  - collection: bl_flows
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_flows
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: account_tree
+      item_duplication_fields: null
+      note: Flow definitions
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_flows
+  - collection: bl_node_types
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_node_types
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: category
+      item_duplication_fields: null
+      note: Available node types
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_node_types
+  - collection: bl_wasm_modules
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_wasm_modules
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_wasm_modules
+  - collection: calculator_calls
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_calls
+      color: null
+      display_template: null
+      group: calculators
+      hidden: true
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 2
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_calls
+  - collection: calculator_configs
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_configs
+      color: null
+      display_template: null
+      group: calculators
+      hidden: true
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_configs
+  - collection: calculator_layouts
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_layouts
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: dashboard_customize
+      item_duplication_fields: null
+      note: Per-calculator widget layout configs (supports multiple versions)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_layouts
+  - collection: calculator_slots
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_slots
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: widgets
+      item_duplication_fields: null
+      note: Pricing v2 — per-calculator slot accounting (size/AO)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_slots
+  - collection: calculator_templates
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_templates
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_templates
+  - collection: calculator_test_cases
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_test_cases
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_test_cases
+  - collection: calculators
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: archived
+      collapse: open
+      collection: calculators
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: sort
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: calculators
+  - collection: feature_quotas
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: feature_quotas
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: speed
+      item_duplication_fields: null
+      note: Pricing v2 — materialized per-account quotas (refreshed by job)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: feature_quotas
+  - collection: formula_examples
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: formula_examples
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: formula_examples
+  - collection: formula_tokens
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: formula_tokens
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: key
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: formula_tokens
+  - collection: kb_answer_feedback
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_answer_feedback
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: thumbs_up_down
+      item_duplication_fields: null
+      note: Answer feedback from users
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_answer_feedback
+  - collection: kb_chunks
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_chunks
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: data_array
+      item_duplication_fields: null
+      note: Knowledge base document chunks with embeddings
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_chunks
+  - collection: kb_curated_answers
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_curated_answers
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: star
+      item_duplication_fields: null
+      note: Curated Q&A pairs for knowledge bases
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_curated_answers
+  - collection: kb_documents
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_documents
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: description
+      item_duplication_fields: null
+      note: Knowledge base documents
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_documents
+  - collection: kb_queries
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_queries
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: query_stats
+      item_duplication_fields: null
+      note: KB query tracking for dashboard charts/KPIs
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_queries
+  - collection: knowledge_bases
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: knowledge_bases
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: menu_book
+      item_duplication_fields: null
+      note: Knowledge base containers
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: knowledge_bases
+  - collection: platform_features
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: platform_features
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: platform_features
+  - collection: stripe_webhook_events
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: stripe_webhook_events
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: stripe_webhook_events
+  - collection: subscription_addons
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: subscription_addons
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: add_circle
+      item_duplication_fields: null
+      note: Pricing v2 — recurring add-on packs (slots/AO/storage)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: subscription_addons
+  - collection: subscription_plans
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: subscription_plans
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: local_offer
+      item_duplication_fields: null
+      note: Pricing v2 — modular catalog (one per module/tier)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: subscription_plans
+  - collection: subscriptions
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: subscriptions
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: verified_user
+      item_duplication_fields: null
+      note: Pricing v2 — per-account-per-module subscriptions
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: subscriptions
+  - collection: system_health_snapshots
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: system_health_snapshots
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: monitor_heart
+      item_duplication_fields: null
+      note: Formula API health snapshots (auto-populated by cron)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: system_health_snapshots
+  - collection: usage_events
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: usage_events
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: event_note
+      item_duplication_fields: null
+      note: Pricing v2 — append-only billable event stream
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: usage_events
+  - collection: wallet_auto_reload_pending
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: wallet_auto_reload_pending
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: autorenew
+      item_duplication_fields: null
+      note: >-
+        Pricing v2 — auto-reload durable queue (ai-api enqueues on low balance;
+        CMS Stripe consumer processes)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: wallet_auto_reload_pending
+  - collection: widget_components
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: widget_components
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: widgets
+      item_duplication_fields: null
+      note: Component registry for calculator widgets
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: widget_components
+  - collection: widget_templates
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: widget_templates
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: view_quilt
+      item_duplication_fields: null
+      note: Layout templates for calculator widgets
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: widget_templates
+  - collection: widget_themes
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: widget_themes
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: palette
+      item_duplication_fields: null
+      note: Theme presets for calculator widgets
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: widget_themes
+fields:
+  - collection: account
+    field: id
+    type: uuid
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: account
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: status
+    type: string
+    meta:
+      collection: account
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: $t:published
+            value: published
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: $t:archived
+            value: archived
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--primary)
+            text: $t:published
+            value: published
+          - color: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - color: var(--theme--warning)
+            text: $t:archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: account
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: user_created
+    type: uuid
+    meta:
+      collection: account
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: account
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: account
+    field: date_created
+    type: timestamp
+    meta:
+      collection: account
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: account
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: user_updated
+    type: uuid
+    meta:
+      collection: account
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: account
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: account
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: account
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: account
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: calculators
+    type: alias
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: calculators
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: account
+    field: users
+    type: alias
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: users
+      group: null
+      hidden: false
+      interface: list-m2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - m2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: account
+    field: name
+    type: string
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: account
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: exempt_from_subscription
+    type: boolean
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: exempt_from_subscription
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: exempt_from_subscription
+      table: account
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_directus_users
+    field: id
+    type: integer
+    meta:
+      collection: account_directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: account_directus_users
+      data_type: integer
+      default_value: nextval('account_directus_users_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_directus_users
+    field: account_id
+    type: uuid
+    meta:
+      collection: account_directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: account_directus_users
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: account_directus_users
+    field: directus_users_id
+    type: uuid
+    meta:
+      collection: account_directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: directus_users_id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: directus_users_id
+      table: account_directus_users
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: account_features
+    field: id
+    type: uuid
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: account_features
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_features
+    field: account
+    type: uuid
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: account_features
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: account_features
+    field: feature
+    type: uuid
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: feature
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: feature
+      table: account_features
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: platform_features
+      foreign_key_column: id
+  - collection: account_features
+    field: enabled
+    type: boolean
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: enabled
+      table: account_features
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_features
+    field: date_created
+    type: timestamp
+    meta:
+      collection: account_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: account_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_features
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: account_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: account_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: account
+    type: uuid
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: related-values
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: ai_conversations
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: total_input_tokens
+    type: integer
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: total_input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: total_input_tokens
+      table: ai_conversations
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: status
+    type: string
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: labels
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Active
+            value: active
+          - text: Archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: ai_conversations
+      data_type: character varying
+      default_value: active
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: messages
+    type: json
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: messages
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: messages
+      table: ai_conversations
+      data_type: json
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: ai_conversations
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: title
+    type: string
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: title
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: title
+      table: ai_conversations
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_conversations
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: id
+    type: uuid
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_conversations
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: model
+    type: string
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: model
+      table: ai_conversations
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: total_output_tokens
+    type: integer
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: total_output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: total_output_tokens
+      table: ai_conversations
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: user_created
+    type: uuid
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: ai_conversations
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: enabled
+    type: boolean
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: boolean
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: enabled
+      table: ai_model_config
+      data_type: boolean
+      default_value: true
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: ai_model_config
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: max_output_tokens
+    type: integer
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: max_output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: max_output_tokens
+      table: ai_model_config
+      data_type: integer
+      default_value: 4096
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: id
+    type: uuid
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_model_config
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_model_config
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: task_category
+    type: string
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: task_category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: task_category
+      table: ai_model_config
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: max_input_tokens
+    type: integer
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: max_input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: max_input_tokens
+      table: ai_model_config
+      data_type: integer
+      default_value: 100000
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: model
+    type: string
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: model
+      table: ai_model_config
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: id
+    type: uuid
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: id
+      table: ai_prompts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: sort
+    type: integer
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sort
+      table: ai_prompts
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_prompts
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: user_created
+    type: uuid
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: ai_prompts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: ai_prompts
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: ai_prompts
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: user_updated
+    type: uuid
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: ai_prompts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: ai_prompts
+    field: meta_prompts_notice
+    type: alias
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: meta_prompts_notice
+      group: null
+      hidden: false
+      interface: presentation-notice
+      note: null
+      options:
+        icon: info
+        text: $t:mcp_prompts_collection_schema.meta_prompts_notice
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - alias
+        - no-data
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: ai_prompts
+    field: name
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: formatted-value
+      display_options:
+        font: monospace
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        slug: true
+        trim: true
+      readonly: false
+      required: true
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: ai_prompts
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: status
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: $t:published
+            value: published
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: $t:archived
+            value: archived
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--primary)
+            text: $t:published
+            value: published
+          - color: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - color: var(--theme--warning)
+            text: $t:archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: ai_prompts
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: description
+    type: text
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: ai_prompts
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: system_prompt
+    type: text
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: system_prompt
+      group: null
+      hidden: false
+      interface: input-rich-text-md
+      note: $t:mcp_prompts_collection_schema.system_prompt_note
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: system_prompt
+      table: ai_prompts
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: messages
+    type: json
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: formatted-json-value
+      display_options:
+        format: '{{ role }} • {{ text }}'
+      field: messages
+      group: null
+      hidden: false
+      interface: list
+      note: $t:mcp_prompts_collection_schema.messages_note
+      options:
+        addLabel: New Message
+        fields:
+          - field: role
+            meta:
+              display: labels
+              display_options:
+                choices:
+                  - icon: person
+                    text: $t:mcp_prompts_collection_schema.messages_role_user
+                    value: user
+                  - icon: smart_toy
+                    text: $t:mcp_prompts_collection_schema.messages_role_assistant
+                    value: assistant
+              field: role
+              interface: select-dropdown
+              note: $t:mcp_prompts_collection_schema.messages_role_note
+              options:
+                choices:
+                  - icon: person
+                    text: $t:mcp_prompts_collection_schema.messages_role_user
+                    value: user
+                  - icon: smart_toy
+                    text: $t:mcp_prompts_collection_schema.messages_role_assistant
+                    value: assistant
+              required: true
+              type: string
+              width: full
+            name: role
+            type: string
+          - field: text
+            meta:
+              display: formatted-value
+              display_options:
+                format: true
+              field: text
+              interface: input-rich-text-md
+              note: >-
+                The actual content of the message. You can use {{ curly_braces
+                }} for placeholders that will be replaced with real data.
+              required: true
+              type: text
+              width: full
+            name: text
+            type: text
+        showConfirmDiscard: true
+        template: '{{ role }} • {{ text }}'
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: messages
+      table: ai_prompts
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: user_prompt_template
+    type: text
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: raw
+      display_options: null
+      field: user_prompt_template
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user_prompt_template
+      table: ai_prompts
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: category
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: raw
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: ai_prompts
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: icon
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: raw
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: ai_prompts
+      data_type: character varying
+      default_value: lightbulb
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_token_usage
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: id
+    type: uuid
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_token_usage
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: cost_usd
+    type: decimal
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '$ '
+      field: cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: cost_usd
+      table: ai_token_usage
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 6
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: account
+    type: uuid
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: related-values
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: ai_token_usage
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_token_usage
+    field: output_tokens
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: output_tokens
+      table: ai_token_usage
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: duration_ms
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: duration_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: duration_ms
+      table: ai_token_usage
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: model
+    type: string
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: model
+      table: ai_token_usage
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: input_tokens
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: input_tokens
+      table: ai_token_usage
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: conversation
+    type: uuid
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: related-values
+      display_options: null
+      field: conversation
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: conversation
+      table: ai_token_usage
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: task_category
+    type: string
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: task_category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: task_category
+      table: ai_token_usage
+      data_type: character varying
+      default_value: null
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: response_time_ms
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: null
+      display_options: null
+      field: response_time_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 999
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response_time_ms
+      table: ai_token_usage
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: tool_calls
+    type: json
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: null
+      display_options: null
+      field: tool_calls
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tool_calls
+      table: ai_token_usage
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: id
+    type: uuid
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet
+    field: balance_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: balance_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: balance_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: 0
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 4
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: monthly_cap_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: monthly_cap_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: monthly_cap_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: auto_reload_enabled
+    type: boolean
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: null
+      display_options: null
+      field: auto_reload_enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: auto_reload_enabled
+      table: ai_wallet
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: auto_reload_threshold_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: auto_reload_threshold_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: auto_reload_threshold_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: auto_reload_amount_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: auto_reload_amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: auto_reload_amount_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: last_topup_at
+    type: timestamp
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: datetime
+      display_options: null
+      field: last_topup_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_topup_at
+      table: ai_wallet
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: last_topup_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: last_topup_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_topup_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: ai_wallet
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: ai_wallet
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: id
+    type: bigInteger
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet_failed_debits
+      data_type: bigint
+      default_value: nextval('ai_wallet_failed_debits_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet_failed_debits
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet_failed_debits
+    field: created_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: datetime
+      display_options: null
+      field: created_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: created_at
+      table: ai_wallet_failed_debits
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: cost_usd
+    type: decimal
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '$ '
+      field: cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cost_usd
+      table: ai_wallet_failed_debits
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: cost_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: cost_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cost_eur
+      table: ai_wallet_failed_debits
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: model
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: model
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: input_tokens
+    type: integer
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input_tokens
+      table: ai_wallet_failed_debits
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: output_tokens
+    type: integer
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: output_tokens
+      table: ai_wallet_failed_debits
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: event_kind
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI Message
+            value: ai.message
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB Ask
+            value: kb.ask
+        showAsDot: true
+      field: event_kind
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: AI Message
+            value: ai.message
+          - color: var(--theme--foreground)
+            text: KB Ask
+            value: kb.ask
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: event_kind
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: module
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: anthropic_request_id
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: anthropic_request_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: anthropic_request_id
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: api_key_id
+    type: uuid
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: api_key_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_key_id
+      table: ai_wallet_failed_debits
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: conversation_id
+    type: uuid
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: conversation_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: conversation_id
+      table: ai_wallet_failed_debits
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: error_reason
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Debit Returned Not OK
+            value: debit_returned_not_ok
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Debit Threw
+            value: debit_threw
+        showAsDot: true
+      field: error_reason
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--danger)
+            text: Debit Returned Not OK
+            value: debit_returned_not_ok
+          - color: var(--theme--danger)
+            text: Debit Threw
+            value: debit_threw
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error_reason
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: error_detail
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: error_detail
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Backend-populated error trace; admin diagnostic.
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error_detail
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: reconciled_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: datetime
+      display_options: null
+      field: reconciled_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: reconciled_at
+      table: ai_wallet_failed_debits
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: reconciliation_method
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Manual
+            value: manual
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Auto
+            value: auto
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Waived
+            value: waived
+        showAsDot: true
+      field: reconciliation_method
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Manual
+            value: manual
+          - color: var(--theme--foreground)
+            text: Auto
+            value: auto
+          - color: var(--theme--foreground)
+            text: Waived
+            value: waived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: reconciliation_method
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: status
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Pending
+            value: pending
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Reconciled
+            value: reconciled
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Waived
+            value: waived
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Pending
+            value: pending
+          - color: var(--theme--success)
+            text: Reconciled
+            value: reconciled
+          - color: var(--theme--foreground)
+            text: Waived
+            value: waived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: pending
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: id
+    type: bigInteger
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet_ledger
+      data_type: bigint
+      default_value: nextval('ai_wallet_ledger_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet_ledger
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet_ledger
+    field: entry_type
+    type: text
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Credit
+            value: credit
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Debit
+            value: debit
+        showAsDot: true
+      field: entry_type
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Credit
+            value: credit
+          - color: var(--theme--danger)
+            text: Debit
+            value: debit
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: entry_type
+      table: ai_wallet_ledger
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: amount_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: amount_eur
+      table: ai_wallet_ledger
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: balance_after_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: balance_after_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: balance_after_eur
+      table: ai_wallet_ledger
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 4
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: source
+    type: text
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Top-up
+            value: topup
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Usage
+            value: usage
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Refund
+            value: refund
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Promo
+            value: promo
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Adjustment
+            value: adjustment
+        showAsDot: true
+      field: source
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--primary)
+            text: Top-up
+            value: topup
+          - color: var(--theme--foreground)
+            text: Usage
+            value: usage
+          - color: var(--theme--foreground)
+            text: Refund
+            value: refund
+          - color: var(--theme--primary)
+            text: Promo
+            value: promo
+          - color: var(--theme--foreground)
+            text: Adjustment
+            value: adjustment
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: source
+      table: ai_wallet_ledger
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: topup_id
+    type: uuid
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: topup_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: topup_id
+      table: ai_wallet_ledger
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: ai_wallet_topup
+      foreign_key_column: id
+  - collection: ai_wallet_ledger
+    field: usage_event_id
+    type: bigInteger
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: usage_event_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: usage_event_id
+      table: ai_wallet_ledger
+      data_type: bigint
+      default_value: null
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: usage_events
+      foreign_key_column: id
+  - collection: ai_wallet_ledger
+    field: metadata
+    type: json
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: metadata
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: metadata
+      table: ai_wallet_ledger
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: occurred_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: datetime
+      display_options: null
+      field: occurred_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: occurred_at
+      table: ai_wallet_ledger
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: id
+    type: uuid
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet_topup
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet_topup
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet_topup
+    field: amount_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: amount_eur
+      table: ai_wallet_topup
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: stripe_payment_intent_id
+    type: text
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_payment_intent_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_payment_intent_id
+      table: ai_wallet_topup
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: stripe_charge_id
+    type: text
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_charge_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_charge_id
+      table: ai_wallet_topup
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: expires_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: datetime
+      display_options: null
+      field: expires_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expires_at
+      table: ai_wallet_topup
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: initiated_by_user_id
+    type: uuid
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: initiated_by_user_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: initiated_by_user_id
+      table: ai_wallet_topup
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: ai_wallet_topup
+    field: is_auto_reload
+    type: boolean
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: is_auto_reload
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: is_auto_reload
+      table: ai_wallet_topup
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: status
+    type: text
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Pending
+            value: pending
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Completed
+            value: completed
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Refunded
+            value: refunded
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Failed
+            value: failed
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Pending
+            value: pending
+          - color: var(--theme--success)
+            text: Completed
+            value: completed
+          - color: var(--theme--foreground)
+            text: Refunded
+            value: refunded
+          - color: var(--theme--danger)
+            text: Failed
+            value: failed
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: ai_wallet_topup
+      data_type: text
+      default_value: completed
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: ai_wallet_topup
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: ai_wallet_topup
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: account_id
+    type: uuid
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: api_keys
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: api_keys
+    field: allowed_ips
+    type: unknown
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: allowed_ips
+      group: null
+      hidden: false
+      interface: tags
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: allowed_ips
+      table: api_keys
+      data_type: text[]
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: allowed_origins
+    type: unknown
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: allowed_origins
+      group: null
+      hidden: false
+      interface: tags
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: allowed_origins
+      table: api_keys
+      data_type: text[]
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: created_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: created_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: created_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: encrypted_key
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: encrypted_key
+      group: null
+      hidden: true
+      interface: input
+      note: AES-256-GCM encrypted key material; never expose.
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: encrypted_key
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: environment
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Live
+            value: live
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Test
+            value: test
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Dev
+            value: dev
+        showAsDot: true
+      field: environment
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Live
+            value: live
+          - color: var(--theme--warning)
+            text: Test
+            value: test
+          - color: var(--theme--foreground)
+            text: Dev
+            value: dev
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: environment
+      table: api_keys
+      data_type: text
+      default_value: live
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: expires_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: expires_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expires_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: key_hash
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: key_hash
+      group: null
+      hidden: true
+      interface: input
+      note: SHA-256 hash of API key; never expose.
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: key_hash
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: key_prefix
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: key_prefix
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: key_prefix
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: last_used_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: last_used_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_used_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: monthly_quota
+    type: integer
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: monthly_quota
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: monthly_quota
+      table: api_keys
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: name
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: permissions
+    type: json
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: permissions
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: permissions
+      table: api_keys
+      data_type: jsonb
+      default_value:
+        ai: true
+        calc: true
+        flow: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: rate_limit_rps
+    type: integer
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: rate_limit_rps
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: rate_limit_rps
+      table: api_keys
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: revoked_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: revoked_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: revoked_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: id
+    type: uuid
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: api_keys
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: ai_spend_cap_monthly_eur
+    type: decimal
+    meta:
+      collection: api_keys
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: ai_spend_cap_monthly_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ai_spend_cap_monthly_eur
+      table: api_keys
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: kb_search_cap_monthly
+    type: integer
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: kb_search_cap_monthly
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: kb_search_cap_monthly
+      table: api_keys
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: module_allowlist
+    type: json
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: module_allowlist
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 19
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module_allowlist
+      table: api_keys
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: flow_id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: flow_id
+      group: null
+      hidden: false
+      interface: input
+      note: Parent flow
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: flow_id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: account_id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account_id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: bl_flow_executions
+    field: status
+    type: text
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: labels
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Pending
+            value: pending
+          - text: Running
+            value: running
+          - text: Completed
+            value: completed
+          - text: Failed
+            value: failed
+          - text: Timed Out
+            value: timed_out
+      readonly: true
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: bl_flow_executions
+      data_type: text
+      default_value: pending
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: trigger_data
+    type: json
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: trigger_data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trigger_data
+      table: bl_flow_executions
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: context
+    type: json
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: context
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: context
+      table: bl_flow_executions
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: result
+    type: json
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: result
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: result
+      table: bl_flow_executions
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: error
+    type: text
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: error
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error
+      table: bl_flow_executions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: duration_ms
+    type: bigInteger
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: duration_ms
+      group: null
+      hidden: false
+      interface: input
+      note: Execution time in ms
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: duration_ms
+      table: bl_flow_executions
+      data_type: bigint
+      default_value: null
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: nodes_executed
+    type: integer
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: nodes_executed
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: nodes_executed
+      table: bl_flow_executions
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: cost_usd
+    type: float
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: AI/LLM cost
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: cost_usd
+      table: bl_flow_executions
+      data_type: real
+      default_value: 0
+      max_length: null
+      numeric_precision: 24
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: worker_id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: worker_id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: worker_id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: started_at
+    type: timestamp
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: started_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: started_at
+      table: bl_flow_executions
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: completed_at
+    type: timestamp
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: completed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: completed_at
+      table: bl_flow_executions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: id
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: name
+    type: text
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: raw
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: Flow name
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: bl_flows
+      data_type: text
+      default_value: Untitled
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: description
+    type: text
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Flow description
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: bl_flows
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: account_id
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: input
+      note: Owner account
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account_id
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: status
+    type: text
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: labels
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Draft
+            value: draft
+          - text: Active
+            value: active
+          - text: Disabled
+            value: disabled
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: bl_flows
+      data_type: text
+      default_value: draft
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: graph
+    type: json
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: graph
+      group: null
+      hidden: false
+      interface: input-code
+      note: Flow DAG (nodes + edges)
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: graph
+      table: bl_flows
+      data_type: json
+      default_value:
+        edges: []
+        nodes: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: trigger_config
+    type: json
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: trigger_config
+      group: null
+      hidden: false
+      interface: input-code
+      note: Trigger configuration
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trigger_config
+      table: bl_flows
+      data_type: json
+      default_value:
+        type: manual
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: settings
+    type: json
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: settings
+      group: null
+      hidden: false
+      interface: input-code
+      note: Execution settings
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: settings
+      table: bl_flows
+      data_type: json
+      default_value: {}
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: version
+    type: integer
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: version
+      group: null
+      hidden: false
+      interface: input
+      note: Optimistic locking version
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version
+      table: bl_flows
+      data_type: integer
+      default_value: 1
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: created_by
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: created_by
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: created_by
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: updated_by
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: updated_by
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: updated_by
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: created_at
+    type: timestamp
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: created_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: created_at
+      table: bl_flows
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: updated_at
+    type: timestamp
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: updated_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: updated_at
+      table: bl_flows
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: id
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: e.g. core:http_request
+      options: null
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_node_types
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: name
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: bl_node_types
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: description
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: bl_node_types
+      data_type: text
+      default_value: ''
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: category
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: bl_node_types
+      data_type: text
+      default_value: utility
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: tier
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: labels
+      display_options: null
+      field: tier
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Core
+            value: core
+          - text: Wasm
+            value: wasm
+          - text: External
+            value: external
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: tier
+      table: bl_node_types
+      data_type: text
+      default_value: core
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: inputs
+    type: json
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: inputs
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: inputs
+      table: bl_node_types
+      data_type: json
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: outputs
+    type: json
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: outputs
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: outputs
+      table: bl_node_types
+      data_type: json
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: config_schema
+    type: json
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: config_schema
+      group: null
+      hidden: false
+      interface: input-code
+      note: JSON Schema for node config
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: config_schema
+      table: bl_node_types
+      data_type: json
+      default_value: {}
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: estimated_cost_usd
+    type: float
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: estimated_cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: estimated_cost_usd
+      table: bl_node_types
+      data_type: real
+      default_value: 0
+      max_length: null
+      numeric_precision: 24
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: required_role
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: labels
+      display_options: null
+      field: required_role
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Any
+            value: any
+          - text: Admin
+            value: admin
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: required_role
+      table: bl_node_types
+      data_type: text
+      default_value: any
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: wasm_module_id
+    type: uuid
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: wasm_module_id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: wasm_module_id
+      table: bl_node_types
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: external_url
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: external_url
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: external_url
+      table: bl_node_types
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: enabled
+    type: boolean
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: enabled
+      table: bl_node_types
+      data_type: boolean
+      default_value: true
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: created_at
+    type: timestamp
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: created_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: created_at
+      table: bl_node_types
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_wasm_modules
+    field: id
+    type: integer
+    meta:
+      collection: bl_wasm_modules
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: numeric
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_wasm_modules
+      data_type: integer
+      default_value: nextval('bl_wasm_modules_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_calls
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: response_time_ms
+    type: integer
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: response_time_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response_time_ms
+      table: calculator_calls
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: error_message
+    type: string
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: error_message
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error_message
+      table: calculator_calls
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: timestamp
+    type: dateTime
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: timestamp
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: timestamp
+      table: calculator_calls
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: cached
+    type: boolean
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: cached
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cached
+      table: calculator_calls
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: error
+    type: boolean
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: error
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error
+      table: calculator_calls
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_calls
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_calls
+    field: test
+    type: boolean
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: test
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test
+      table: calculator_calls
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: account
+    type: uuid
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: calculator_calls
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: calculator_configs
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: calculator_configs
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: input
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: input
+      group: null
+      hidden: false
+      interface: input-code
+      note: Input json schema
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: output
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: output
+      group: null
+      hidden: false
+      interface: input-code
+      note: Output json schema
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: output
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_configs
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: sheets
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: sheets
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheets
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: formulas
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formulas
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: test_environment
+    type: boolean
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: test_environment
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options:
+        choices: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test_environment
+      table: calculator_configs
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: description
+    type: text
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: calculator_configs
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: excel_file
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: file
+      display_options: null
+      field: excel_file
+      group: null
+      hidden: false
+      interface: file
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - file
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: excel_file
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_files
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: file_version
+    type: integer
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: file_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: file_version
+      table: calculator_configs
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: config_version
+    type: integer
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: config_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: config_version
+      table: calculator_configs
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: api_key
+    type: string
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: api_key
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_key
+      table: calculator_configs
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: data
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: data
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: integration
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: integration
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: integration
+      table: calculator_configs
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: mcp
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: mcp
+      group: null
+      hidden: false
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: mcp
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: expressions
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: expressions
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expressions
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: profile
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: profile
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: profile
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: unresolved_functions
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: unresolved_functions
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: unresolved_functions
+      table: calculator_configs
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: Linked calculator
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_layouts
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_layouts
+    field: layout_config
+    type: json
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: layout_config
+      group: null
+      hidden: false
+      interface: input-code
+      note: Full layout config JSON
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: layout_config
+      table: calculator_layouts
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: theme
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: theme
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: Optional theme override
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: theme
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: widget_themes
+      foreign_key_column: id
+  - collection: calculator_layouts
+    field: template
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: template
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: Template used as base
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: template
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: widget_templates
+      foreign_key_column: id
+  - collection: calculator_layouts
+    field: version
+    type: string
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version
+      table: calculator_layouts
+      data_type: character varying
+      default_value: '1.0'
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: status
+    type: string
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: calculator_layouts
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: calculator_layouts
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: calculator_layouts
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user_created
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user_updated
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_slots
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: account_id
+    type: uuid
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: calculator_slots
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: calculator_slots
+    field: calculator_config_id
+    type: uuid
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator_config_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator_config_id
+      table: calculator_slots
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculator_configs
+      foreign_key_column: id
+  - collection: calculator_slots
+    field: slots_consumed
+    type: integer
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: slots_consumed
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slots_consumed
+      table: calculator_slots
+      data_type: integer
+      default_value: 1
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: is_always_on
+    type: boolean
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: is_always_on
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: is_always_on
+      table: calculator_slots
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: size_class
+    type: text
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: size_class
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: size_class
+      table: calculator_slots
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: file_version
+    type: integer
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: file_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: file_version
+      table: calculator_slots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: config_version
+    type: integer
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: config_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: config_version
+      table: calculator_slots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: computed_at
+    type: timestamp
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: computed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: computed_at
+      table: calculator_slots
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: calculator_slots
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: calculator_slots
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: sort
+    type: integer
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: calculator_templates
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: name
+    type: string
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: calculator_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: description
+    type: text
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: calculator_templates
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: icon
+    type: string
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: select-icon
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: calculator_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: sheets
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: sheets
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheets
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: formulas
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formulas
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: input
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: input
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: output
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: output
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: output
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: featured
+    type: boolean
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: featured
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: featured
+      table: calculator_templates
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: industry
+    type: string
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: industry
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: industry
+      table: calculator_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_test_cases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: calculator_test_cases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_test_cases
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: calculator_test_cases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: calculator_test_cases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_test_cases
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: calculator_test_cases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: input
+    type: json
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: input
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input
+      table: calculator_test_cases
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_test_cases
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_test_cases
+    field: name
+    type: string
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: calculator_test_cases
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: sort
+    type: integer
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: calculator_test_cases
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: expected_outputs
+    type: json
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: expected_outputs
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expected_outputs
+      table: calculator_test_cases
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: tolerance
+    type: float
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: tolerance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tolerance
+      table: calculator_test_cases
+      data_type: real
+      default_value: null
+      max_length: null
+      numeric_precision: 24
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: id
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        slug: true
+        trim: true
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: id
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: sort
+    type: integer
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: calculators
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculators
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: calculators
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculators
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculators
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: calculators
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculators
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: calculators
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculators
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculators
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: calculators
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: configs
+    type: alias
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: configs
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: calculators
+    field: account
+    type: uuid
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: calculators
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: calculators
+    field: name
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: description
+    type: text
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: calculators
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: test_cases
+    type: alias
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: test_cases
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: calculators
+    field: calculator_calls
+    type: alias
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator_calls
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: calculators
+    field: activated
+    type: boolean
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: activated
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: activated
+      table: calculators
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: onboarded
+    type: boolean
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: onboarded
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: onboarded
+      table: calculators
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: ai_name
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: ai_name
+      group: null
+      hidden: false
+      interface: input
+      note: >-
+        General AI-facing name. Used by MCP, Skill, and Plugin unless
+        overridden. Defaults to calculator name.
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ai_name
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: test_expires_at
+    type: dateTime
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: test_expires_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test_expires_at
+      table: calculators
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: activation_expires_at
+    type: dateTime
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: activation_expires_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: activation_expires_at
+      table: calculators
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: over_limit
+    type: boolean
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: over_limit
+      group: null
+      hidden: true
+      interface: boolean
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 19
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: over_limit
+      table: calculators
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: icon
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: select-icon
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: icon
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: test_enabled_at
+    type: dateTime
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: test_enabled_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test_enabled_at
+      table: calculators
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: directus_files
+    field: calculator_config
+    type: alias
+    meta:
+      collection: directus_files
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator_config
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: directus_users
+    field: accounts
+    type: alias
+    meta:
+      collection: directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: accounts
+      group: null
+      hidden: false
+      interface: list-m2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - m2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: directus_users
+    field: active_account
+    type: uuid
+    meta:
+      collection: directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: active_account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: active_account
+      table: directus_users
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: feature_quotas
+    field: id
+    type: uuid
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: feature_quotas
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: account_id
+    type: uuid
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: feature_quotas
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: feature_quotas
+    field: module
+    type: unknown
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: feature_quotas
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: slot_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: slot_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slot_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: ao_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: ao_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ao_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: request_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: request_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: request_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: storage_mb
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: storage_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: storage_mb
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: embed_tokens_m
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: embed_tokens_m
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embed_tokens_m
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: executions
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: executions
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: executions
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: max_steps
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: max_steps
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: max_steps
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: concurrent_runs
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: concurrent_runs
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: concurrent_runs
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: scheduled_triggers
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: scheduled_triggers
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: scheduled_triggers
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: api_keys_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: api_keys_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_keys_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: users_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: users_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: users_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: source_subscription_id
+    type: uuid
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: source_subscription_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: source_subscription_id
+      table: feature_quotas
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+  - collection: feature_quotas
+    field: refreshed_at
+    type: timestamp
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: datetime
+      display_options: null
+      field: refreshed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: refreshed_at
+      table: feature_quotas
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: date_created
+    type: timestamp
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 17
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: feature_quotas
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 18
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: feature_quotas
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: id
+    type: uuid
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: formula_examples
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sort
+    type: integer
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sort
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sort
+      table: formula_examples
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: label
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: label
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: label
+      table: formula_examples
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: mode
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: mode
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Single
+            value: single
+          - text: Batch
+            value: batch
+          - text: Sheet
+            value: sheet
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: mode
+      table: formula_examples
+      data_type: character varying
+      default_value: single
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: advanced
+    type: boolean
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: boolean
+      display_options: null
+      field: advanced
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: advanced
+      table: formula_examples
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: formula
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: formula
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formula
+      table: formula_examples
+      data_type: character varying
+      default_value: null
+      max_length: 1000
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: formulas
+    type: json
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formulas
+      table: formula_examples
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sheet_formulas
+    type: json
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sheet_formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheet_formulas
+      table: formula_examples
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: data
+    type: text
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: data
+      table: formula_examples
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sheet_data
+    type: text
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sheet_data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheet_data
+      table: formula_examples
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sheet_data_mode
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sheet_data_mode
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Data
+            value: data
+          - text: Sheets
+            value: sheets
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sheet_data_mode
+      table: formula_examples
+      data_type: character varying
+      default_value: data
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: id
+    type: uuid
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: formula_tokens
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: account
+    type: uuid
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: formula_tokens
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: formula_tokens
+    field: label
+    type: string
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: label
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: label
+      table: formula_tokens
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: token
+    type: text
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: token
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: token
+      table: formula_tokens
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: date_created
+    type: timestamp
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: formula_tokens
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: last_used_at
+    type: timestamp
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: last_used_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_used_at
+      table: formula_tokens
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: revoked
+    type: boolean
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: revoked
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: revoked
+      table: formula_tokens
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: revoked_at
+    type: timestamp
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: revoked_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: revoked_at
+      table: formula_tokens
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: id
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_answer_feedback
+    field: account
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_answer_feedback
+    field: conversation_id
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: conversation_id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: conversation_id
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: query
+    type: text
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: query
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: query
+      table: kb_answer_feedback
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: answer_hash
+    type: string
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: answer_hash
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: answer_hash
+      table: kb_answer_feedback
+      data_type: character varying
+      default_value: null
+      max_length: 64
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: rating
+    type: string
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: rating
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: rating
+      table: kb_answer_feedback
+      data_type: character varying
+      default_value: null
+      max_length: 10
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: category
+    type: string
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: kb_answer_feedback
+      data_type: character varying
+      default_value: null
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: comment
+    type: text
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: comment
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: comment
+      table: kb_answer_feedback
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: chunks_used
+    type: json
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: chunks_used
+      group: null
+      hidden: true
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: chunks_used
+      table: kb_answer_feedback
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: chunk_scores
+    type: json
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_scores
+      group: null
+      hidden: true
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: chunk_scores
+      table: kb_answer_feedback
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: response_text
+    type: text
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: response_text
+      group: null
+      hidden: true
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response_text
+      table: kb_answer_feedback
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: user_created
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_answer_feedback
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: id
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_chunks
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: document
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: document
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: document
+      table: kb_chunks
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+  - collection: kb_chunks
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_chunks
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_chunks
+    field: account_id
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account_id
+      table: kb_chunks
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: chunk_index
+    type: integer
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_index
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: chunk_index
+      table: kb_chunks
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: content
+    type: text
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: content
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: content
+      table: kb_chunks
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: embedding
+    type: unknown
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: embedding
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embedding
+      table: kb_chunks
+      data_type: vector
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: metadata
+    type: json
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: metadata
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: metadata
+      table: kb_chunks
+      data_type: jsonb
+      default_value: {}
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: token_count
+    type: integer
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: token_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: token_count
+      table: kb_chunks
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_chunks
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: contextual_content
+    type: text
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: contextual_content
+      group: null
+      hidden: true
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: contextual_content
+      table: kb_chunks
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: search_vector
+    type: unknown
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: search_vector
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: search_vector
+      table: kb_chunks
+      data_type: tsvector
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: language
+    type: string
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: language
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: language
+      table: kb_chunks
+      data_type: character varying
+      default_value: null
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: content_hash
+    type: string
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: content_hash
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: content_hash
+      table: kb_chunks
+      data_type: character varying
+      default_value: null
+      max_length: 64
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: id
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_curated_answers
+    field: account
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_curated_answers
+    field: question
+    type: text
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: question
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: question
+      table: kb_curated_answers
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: answer
+    type: text
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: answer
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: answer
+      table: kb_curated_answers
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: keywords
+    type: json
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: keywords
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: keywords
+      table: kb_curated_answers
+      data_type: jsonb
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: embedding
+    type: unknown
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: embedding
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embedding
+      table: kb_curated_answers
+      data_type: vector
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: priority
+    type: string
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: priority
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: priority
+      table: kb_curated_answers
+      data_type: character varying
+      default_value: boost
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: source_document
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: source_document
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: source_document
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+  - collection: kb_curated_answers
+    field: status
+    type: string
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: kb_curated_answers
+      data_type: character varying
+      default_value: published
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: usage_count
+    type: integer
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: usage_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: usage_count
+      table: kb_curated_answers
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: last_served
+    type: timestamp
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: last_served
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_served
+      table: kb_curated_answers
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_curated_answers
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: kb_curated_answers
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: language
+    type: string
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: language
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: language
+      table: kb_curated_answers
+      data_type: character varying
+      default_value: eng
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: id
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_documents
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_documents
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_documents
+    field: account
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: kb_documents
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_documents
+    field: file
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: file
+      group: null
+      hidden: false
+      interface: file
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: file
+      table: kb_documents
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_files
+      foreign_key_column: id
+  - collection: kb_documents
+    field: title
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: title
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: title
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 500
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: file_type
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: file_type
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: file_type
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: file_size
+    type: bigInteger
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: file_size
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: file_size
+      table: kb_documents
+      data_type: bigint
+      default_value: 0
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: chunk_count
+    type: integer
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: chunk_count
+      table: kb_documents
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: version_hash
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: version_hash
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version_hash
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 64
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: indexing_status
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: indexing_status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: indexing_status
+      table: kb_documents
+      data_type: character varying
+      default_value: pending
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: indexing_error
+    type: text
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: indexing_error
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: indexing_error
+      table: kb_documents
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: last_indexed
+    type: timestamp
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: last_indexed
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_indexed
+      table: kb_documents
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_documents
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: language
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: language
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: language
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: id
+    type: uuid
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_queries
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: related-values
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: FK to knowledge_bases
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: knowledge_base
+      table: kb_queries
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_queries
+    field: account
+    type: uuid
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: related-values
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: FK to account
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: kb_queries
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_queries
+    field: query
+    type: text
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: null
+      display_options: null
+      field: query
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Search/ask query text
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: query
+      table: kb_queries
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: type
+    type: string
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: raw
+      display_options: null
+      field: type
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: search or ask
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: type
+      table: kb_queries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: result_count
+    type: integer
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: null
+      display_options: null
+      field: result_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: result_count
+      table: kb_queries
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: timestamp
+    type: timestamp
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: datetime
+      display_options: null
+      field: timestamp
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: timestamp
+      table: kb_queries
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_queries
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: id
+    type: uuid
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: knowledge_bases
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: account
+    type: uuid
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: knowledge_bases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: knowledge_bases
+    field: name
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: knowledge_bases
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: description
+    type: text
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: knowledge_bases
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: icon
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: knowledge_bases
+      data_type: character varying
+      default_value: menu_book
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: document_count
+    type: integer
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: document_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: document_count
+      table: knowledge_bases
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: chunk_count
+    type: integer
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: chunk_count
+      table: knowledge_bases
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: last_indexed
+    type: timestamp
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: last_indexed
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_indexed
+      table: knowledge_bases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: embedding_model
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: embedding_model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: embedding_model
+      table: knowledge_bases
+      data_type: character varying
+      default_value: text-embedding-3-small
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: status
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: knowledge_bases
+      data_type: character varying
+      default_value: active
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: sort
+    type: integer
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sort
+      table: knowledge_bases
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: date_created
+    type: timestamp
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: knowledge_bases
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: knowledge_bases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: id
+    type: uuid
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: platform_features
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: key
+    type: string
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: key
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: key
+      table: platform_features
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: name
+    type: string
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: platform_features
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: description
+    type: text
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: platform_features
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: enabled
+    type: boolean
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: enabled
+      table: platform_features
+      data_type: boolean
+      default_value: true
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: category
+    type: string
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: category
+      table: platform_features
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: sort
+    type: integer
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: platform_features
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: date_created
+    type: timestamp
+    meta:
+      collection: platform_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: platform_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: platform_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: platform_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: id
+    type: bigInteger
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: stripe_webhook_events
+      data_type: bigint
+      default_value: nextval('stripe_webhook_events_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: stripe_event_id
+    type: text
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_event_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_event_id
+      table: stripe_webhook_events
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: event_type
+    type: text
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: event_type
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: event_type
+      table: stripe_webhook_events
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: processed_at
+    type: timestamp
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: datetime
+      display_options: null
+      field: processed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: processed_at
+      table: stripe_webhook_events
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: payload
+    type: json
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: payload
+      group: null
+      hidden: true
+      interface: input-code
+      note: Raw Stripe webhook payload — sensitive; admin-only.
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: payload
+      table: stripe_webhook_events
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: id
+    type: uuid
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: subscription_addons
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: account_id
+    type: uuid
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: subscription_addons
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: subscription_addons
+    field: subscription_id
+    type: uuid
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: subscription_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: subscription_id
+      table: subscription_addons
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+  - collection: subscription_addons
+    field: addon_kind
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: addon_kind
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addon_kind
+      table: subscription_addons
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: quantity
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: quantity
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: quantity
+      table: subscription_addons
+      data_type: integer
+      default_value: 1
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: slot_allowance_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: slot_allowance_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slot_allowance_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: ao_allowance_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: ao_allowance_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ao_allowance_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: storage_mb_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: storage_mb_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: storage_mb_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: request_allowance_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: request_allowance_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: request_allowance_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: stripe_subscription_item_id
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_subscription_item_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_subscription_item_id
+      table: subscription_addons
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: stripe_price_id
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_price_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_price_id
+      table: subscription_addons
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: price_eur_monthly
+    type: decimal
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: price_eur_monthly
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: price_eur_monthly
+      table: subscription_addons
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: currency
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: currency
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: currency
+      table: subscription_addons
+      data_type: text
+      default_value: EUR
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: status
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Active
+            value: active
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Expired
+            value: expired
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Active
+            value: active
+          - color: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - color: var(--theme--danger)
+            text: Expired
+            value: expired
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: subscription_addons
+      data_type: text
+      default_value: active
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: current_period_start
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_start
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_start
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: current_period_end
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_end
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_end
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: cancel_at
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: cancel_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cancel_at
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: date_created
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 18
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 19
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: kb_limit
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: kb_limit
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: kb_limit
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: kb_storage_mb
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: kb_storage_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 21
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: kb_storage_mb
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: id
+    type: uuid
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: subscription_plans
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: module
+    type: unknown
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: subscription_plans
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: tier
+    type: unknown
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Growth
+            value: growth
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Scale
+            value: scale
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+        showAsDot: true
+      field: tier
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - color: var(--theme--primary)
+            text: Growth
+            value: growth
+          - color: var(--theme--primary)
+            text: Scale
+            value: scale
+          - color: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tier
+      table: subscription_plans
+      data_type: tier_level
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: name
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: status
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Published
+            value: published
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Draft
+            value: draft
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Archived
+            value: archived
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Published
+            value: published
+          - color: var(--theme--warning)
+            text: Draft
+            value: draft
+          - color: var(--theme--foreground)
+            text: Archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: subscription_plans
+      data_type: text
+      default_value: draft
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: stripe_product_id
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_product_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_product_id
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: stripe_price_monthly_id
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_price_monthly_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_price_monthly_id
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: stripe_price_annual_id
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_price_annual_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_price_annual_id
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: price_eur_monthly
+    type: decimal
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: price_eur_monthly
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: price_eur_monthly
+      table: subscription_plans
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: price_eur_annual
+    type: decimal
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: price_eur_annual
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: price_eur_annual
+      table: subscription_plans
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: currency_variants
+    type: json
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: currency_variants
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: currency_variants
+      table: subscription_plans
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: slot_allowance
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: slot_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slot_allowance
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: ao_allowance
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: ao_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ao_allowance
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: request_allowance
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: request_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: request_allowance
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: storage_mb
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: storage_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: storage_mb
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: embed_tokens_m
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: embed_tokens_m
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embed_tokens_m
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: executions
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: executions
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: executions
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: max_steps
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: max_steps
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: max_steps
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: concurrent_runs
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: concurrent_runs
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 19
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: concurrent_runs
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: scheduled_triggers
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: scheduled_triggers
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: scheduled_triggers
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: included_api_keys
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: included_api_keys
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 21
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: included_api_keys
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: included_users
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: included_users
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 22
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: included_users
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: trial_days
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: trial_days
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 23
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trial_days
+      table: subscription_plans
+      data_type: integer
+      default_value: 14
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: sort
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 24
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: date_created
+    type: timestamp
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 25
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: subscription_plans
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 26
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: subscription_plans
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: id
+    type: uuid
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: subscriptions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: account_id
+    type: uuid
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: subscriptions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: subscriptions
+    field: subscription_plan_id
+    type: uuid
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: subscription_plan_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: subscription_plan_id
+      table: subscriptions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: subscription_plans
+      foreign_key_column: id
+  - collection: subscriptions
+    field: module
+    type: unknown
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: subscriptions
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: tier
+    type: unknown
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Growth
+            value: growth
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Scale
+            value: scale
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+        showAsDot: true
+      field: tier
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - color: var(--theme--primary)
+            text: Growth
+            value: growth
+          - color: var(--theme--primary)
+            text: Scale
+            value: scale
+          - color: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tier
+      table: subscriptions
+      data_type: tier_level
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: status
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Trialing
+            value: trialing
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Active
+            value: active
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Past Due
+            value: past_due
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Expired
+            value: expired
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Trialing
+            value: trialing
+          - color: var(--theme--success)
+            text: Active
+            value: active
+          - color: var(--theme--danger)
+            text: Past Due
+            value: past_due
+          - color: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - color: var(--theme--danger)
+            text: Expired
+            value: expired
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: billing_cycle
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Monthly
+            value: monthly
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Annual
+            value: annual
+        showAsDot: true
+      field: billing_cycle
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Monthly
+            value: monthly
+          - color: var(--theme--success)
+            text: Annual
+            value: annual
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: billing_cycle
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: stripe_customer_id
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_customer_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_customer_id
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: stripe_subscription_id
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_subscription_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_subscription_id
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: current_period_start
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_start
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_start
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: current_period_end
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_end
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_end
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: trial_start
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: trial_start
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trial_start
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: trial_end
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: trial_end
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trial_end
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: cancel_at
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: cancel_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cancel_at
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: grandfather_price_eur
+    type: decimal
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: grandfather_price_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: grandfather_price_eur
+      table: subscriptions
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: date_created
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 16
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 17
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: queue_pending
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: queue_pending
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: queue_pending
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: heap_used_mb
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: heap_used_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: heap_used_mb
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: response_time_ms
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: response_time_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: response_time_ms
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: worker_count
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: worker_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: worker_count
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: response
+    type: json
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: response
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response
+      table: system_health_snapshots
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: status
+    type: string
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: system_health_snapshots
+      data_type: character varying
+      default_value: unknown
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: cache_size
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: cache_size
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: cache_size
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: date_created
+    type: timestamp
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: system_health_snapshots
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: queue_max
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: queue_max
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: queue_max
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: id
+    type: uuid
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: system_health_snapshots
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: instance_count
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: null
+      display_options: null
+      field: instance_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: instance_count
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: total_calculators
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: null
+      display_options: null
+      field: total_calculators
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: total_calculators
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: id
+    type: bigInteger
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: usage_events
+      data_type: bigint
+      default_value: nextval('usage_events_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: account_id
+    type: uuid
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: usage_events
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: usage_events
+    field: api_key_id
+    type: uuid
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: api_key_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_key_id
+      table: usage_events
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: module
+    type: unknown
+    meta:
+      collection: usage_events
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: usage_events
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: event_kind
+    type: text
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: event_kind
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: event_kind
+      table: usage_events
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: quantity
+    type: decimal
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: quantity
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: quantity
+      table: usage_events
+      data_type: numeric
+      default_value: 1
+      max_length: null
+      numeric_precision: 20
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: cost_eur
+    type: decimal
+    meta:
+      collection: usage_events
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: cost_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cost_eur
+      table: usage_events
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: metadata
+    type: json
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: metadata
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: metadata
+      table: usage_events
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: occurred_at
+    type: timestamp
+    meta:
+      collection: usage_events
+      conditions: null
+      display: datetime
+      display_options: null
+      field: occurred_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: occurred_at
+      table: usage_events
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: aggregated_at
+    type: timestamp
+    meta:
+      collection: usage_events
+      conditions: null
+      display: datetime
+      display_options: null
+      field: aggregated_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: aggregated_at
+      table: usage_events
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: id
+    type: uuid
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: wallet_auto_reload_pending
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: account_id
+    type: uuid
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: wallet_auto_reload_pending
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: wallet_auto_reload_pending
+    field: amount_eur
+    type: decimal
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: amount_eur
+      table: wallet_auto_reload_pending
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 4
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: created_at
+    type: timestamp
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: datetime
+      display_options: null
+      field: created_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: created_at
+      table: wallet_auto_reload_pending
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: status
+    type: text
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Pending
+            value: pending
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Processing
+            value: processing
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Succeeded
+            value: succeeded
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Failed
+            value: failed
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Cancelled
+            value: cancelled
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Pending
+            value: pending
+          - color: var(--theme--warning)
+            text: Processing
+            value: processing
+          - color: var(--theme--success)
+            text: Succeeded
+            value: succeeded
+          - color: var(--theme--danger)
+            text: Failed
+            value: failed
+          - color: var(--theme--foreground)
+            text: Cancelled
+            value: cancelled
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: wallet_auto_reload_pending
+      data_type: text
+      default_value: pending
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: processed_at
+    type: timestamp
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: datetime
+      display_options: null
+      field: processed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: processed_at
+      table: wallet_auto_reload_pending
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: stripe_payment_intent_id
+    type: text
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_payment_intent_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_payment_intent_id
+      table: wallet_auto_reload_pending
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: last_error
+    type: text
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: last_error
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_error
+      table: wallet_auto_reload_pending
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: attempts
+    type: integer
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: attempts
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: attempts
+      table: wallet_auto_reload_pending
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: id
+    type: uuid
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: widget_components
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: slug
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: slug
+      group: null
+      hidden: false
+      interface: input
+      note: Unique identifier (e.g. slider, bar-chart)
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: slug
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: name
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: description
+    type: text
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: widget_components
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: category
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Input
+            value: input
+          - text: Output
+            value: output
+          - text: Layout
+            value: layout
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: widget_components
+      data_type: character varying
+      default_value: input
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: icon
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: input
+      note: Material icon name
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: renderer_type
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: renderer_type
+      group: null
+      hidden: false
+      interface: input
+      note: Lit custom element tag (e.g. bl-slider)
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: renderer_type
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: default_props
+    type: json
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: default_props
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: default_props
+      table: widget_components
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: prop_schema
+    type: json
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: prop_schema
+      group: null
+      hidden: false
+      interface: input-code
+      note: JSON Schema for component props
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: prop_schema
+      table: widget_components
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: field_types
+    type: json
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: field_types
+      group: null
+      hidden: false
+      interface: input-code
+      note: Which calculator field types this binds to
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: field_types
+      table: widget_components
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: supports_animation
+    type: boolean
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: supports_animation
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: supports_animation
+      table: widget_components
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: lazy_load
+    type: boolean
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: lazy_load
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: lazy_load
+      table: widget_components
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: sort
+    type: integer
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: widget_components
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: status
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: widget_components
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: version
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version
+      table: widget_components
+      data_type: character varying
+      default_value: '1.0'
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: id
+    type: uuid
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: widget_templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: name
+    type: string
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: widget_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: slug
+    type: string
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: slug
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: slug
+      table: widget_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: description
+    type: text
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: widget_templates
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: thumbnail
+    type: uuid
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: thumbnail
+      group: null
+      hidden: false
+      interface: file-image
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - file
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: thumbnail
+      table: widget_templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: layout_skeleton
+    type: json
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: layout_skeleton
+      group: null
+      hidden: false
+      interface: input-code
+      note: Pre-defined layout tree with empty slots
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: layout_skeleton
+      table: widget_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: status
+    type: string
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: widget_templates
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: sort
+    type: integer
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: widget_templates
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: id
+    type: uuid
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: widget_themes
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: name
+    type: string
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: widget_themes
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: slug
+    type: string
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: slug
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: slug
+      table: widget_themes
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: variables
+    type: json
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: variables
+      group: null
+      hidden: false
+      interface: input-code
+      note: CSS custom property values
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: variables
+      table: widget_themes
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: status
+    type: string
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: widget_themes
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: sort
+    type: integer
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: widget_themes
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+systemFields: []
+relations:
+  - collection: account
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: account
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: account_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: account
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: account
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: account_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: account_directus_users
+    field: directus_users_id
+    related_collection: directus_users
+    meta:
+      junction_field: account_id
+      many_collection: account_directus_users
+      many_field: directus_users_id
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: accounts
+      sort_field: null
+    schema:
+      table: account_directus_users
+      column: directus_users_id
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: account_directus_users_directus_users_id_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: account_directus_users
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: directus_users_id
+      many_collection: account_directus_users
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: users
+      sort_field: null
+    schema:
+      table: account_directus_users
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: account_directus_users_account_id_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: account_features
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: account_features
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account_features
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: account_features_account_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: account_features
+    field: feature
+    related_collection: platform_features
+    meta:
+      junction_field: null
+      many_collection: account_features
+      many_field: feature
+      one_allowed_collections: null
+      one_collection: platform_features
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account_features
+      column: feature
+      foreign_key_table: platform_features
+      foreign_key_column: id
+      constraint_name: account_features_feature_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: ai_prompts
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: ai_prompts
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_prompts
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: ai_prompts_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: ai_prompts
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: ai_prompts
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_prompts
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: ai_prompts_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: ai_wallet
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_failed_debits
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_failed_debits
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_failed_debits
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_failed_debits_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_ledger
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_ledger
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_ledger
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_ledger_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_ledger
+    field: topup_id
+    related_collection: ai_wallet_topup
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_ledger
+      many_field: topup_id
+      one_allowed_collections: null
+      one_collection: ai_wallet_topup
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_ledger
+      column: topup_id
+      foreign_key_table: ai_wallet_topup
+      foreign_key_column: id
+      constraint_name: ai_wallet_ledger_topup_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: ai_wallet_ledger
+    field: usage_event_id
+    related_collection: usage_events
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_ledger
+      many_field: usage_event_id
+      one_allowed_collections: null
+      one_collection: usage_events
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_ledger
+      column: usage_event_id
+      foreign_key_table: usage_events
+      foreign_key_column: id
+      constraint_name: ai_wallet_ledger_usage_event_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: ai_wallet_topup
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_topup
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_topup
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_topup_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_topup
+    field: initiated_by_user_id
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_topup
+      many_field: initiated_by_user_id
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_topup
+      column: initiated_by_user_id
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: ai_wallet_topup_initiated_by_user_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: api_keys
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: api_keys
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: api_keys
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: api_keys_account_id_fkey
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_calls
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_calls
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: calculator_calls
+      sort_field: null
+    schema:
+      table: calculator_calls
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_calls_calculator_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_configs
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_configs_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_configs
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_configs_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_configs
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: configs
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_configs_calculator_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_configs
+    field: excel_file
+    related_collection: directus_files
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: excel_file
+      one_allowed_collections: null
+      one_collection: directus_files
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: calculator_config
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: excel_file
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      constraint_name: calculator_configs_excel_file_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_layouts
+    field: theme
+    related_collection: widget_themes
+    meta:
+      junction_field: null
+      many_collection: calculator_layouts
+      many_field: theme
+      one_allowed_collections: null
+      one_collection: widget_themes
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_layouts
+      column: theme
+      foreign_key_table: widget_themes
+      foreign_key_column: id
+      constraint_name: calculator_layouts_theme_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_layouts
+    field: template
+    related_collection: widget_templates
+    meta:
+      junction_field: null
+      many_collection: calculator_layouts
+      many_field: template
+      one_allowed_collections: null
+      one_collection: widget_templates
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_layouts
+      column: template
+      foreign_key_table: widget_templates
+      foreign_key_column: id
+      constraint_name: calculator_layouts_template_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_layouts
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_layouts
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_layouts
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_layouts_calculator_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_slots
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: calculator_slots
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_slots
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: calculator_slots_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_slots
+    field: calculator_config_id
+    related_collection: calculator_configs
+    meta:
+      junction_field: null
+      many_collection: calculator_slots
+      many_field: calculator_config_id
+      one_allowed_collections: null
+      one_collection: calculator_configs
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_slots
+      column: calculator_config_id
+      foreign_key_table: calculator_configs
+      foreign_key_column: id
+      constraint_name: calculator_slots_calculator_config_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_test_cases
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_test_cases
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_test_cases
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_test_cases_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_test_cases
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_test_cases
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_test_cases
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_test_cases_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_test_cases
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_test_cases
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: test_cases
+      sort_field: null
+    schema:
+      table: calculator_test_cases
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_test_cases_calculator_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculators
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculators
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculators
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculators_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculators
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculators
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculators
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculators_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculators
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: calculators
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: calculators
+      sort_field: null
+    schema:
+      table: calculators
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: calculators_account_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: directus_users
+    field: active_account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: directus_users
+      many_field: active_account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: directus_users
+      column: active_account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: directus_users_active_account_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: feature_quotas
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: feature_quotas
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: feature_quotas
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: feature_quotas_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: feature_quotas
+    field: source_subscription_id
+    related_collection: subscriptions
+    meta:
+      junction_field: null
+      many_collection: feature_quotas
+      many_field: source_subscription_id
+      one_allowed_collections: null
+      one_collection: subscriptions
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: feature_quotas
+      column: source_subscription_id
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+      constraint_name: feature_quotas_source_subscription_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: formula_tokens
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: formula_tokens
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: formula_tokens
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: formula_tokens_account_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_answer_feedback
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_answer_feedback
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_answer_feedback
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_answer_feedback_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_answer_feedback
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_answer_feedback
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_answer_feedback
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_answer_feedback_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_chunks
+    field: document
+    related_collection: kb_documents
+    meta:
+      junction_field: null
+      many_collection: kb_chunks
+      many_field: document
+      one_allowed_collections: null
+      one_collection: kb_documents
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_chunks
+      column: document
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+      constraint_name: kb_chunks_document_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_chunks
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_chunks
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_chunks
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_chunks_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_curated_answers
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_curated_answers
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_curated_answers
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_curated_answers_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_curated_answers
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_curated_answers
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_curated_answers
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_curated_answers_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_curated_answers
+    field: source_document
+    related_collection: kb_documents
+    meta:
+      junction_field: null
+      many_collection: kb_curated_answers
+      many_field: source_document
+      one_allowed_collections: null
+      one_collection: kb_documents
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_curated_answers
+      column: source_document
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+      constraint_name: kb_curated_answers_source_document_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_documents
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_documents
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_documents
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_documents_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_documents
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_documents
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_documents
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_documents_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_documents
+    field: file
+    related_collection: directus_files
+    meta:
+      junction_field: null
+      many_collection: kb_documents
+      many_field: file
+      one_allowed_collections: null
+      one_collection: directus_files
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_documents
+      column: file
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      constraint_name: kb_documents_file_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_queries
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_queries
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_queries
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_queries_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_queries
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_queries
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_queries
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_queries_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: knowledge_bases
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: knowledge_bases
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: knowledge_bases
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: knowledge_bases_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: subscription_addons
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: subscription_addons
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscription_addons
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: subscription_addons_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: subscription_addons
+    field: subscription_id
+    related_collection: subscriptions
+    meta:
+      junction_field: null
+      many_collection: subscription_addons
+      many_field: subscription_id
+      one_allowed_collections: null
+      one_collection: subscriptions
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscription_addons
+      column: subscription_id
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+      constraint_name: subscription_addons_subscription_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: subscriptions
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: subscriptions
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscriptions
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: subscriptions_account_id_fkey
+      on_update: NO ACTION
+      on_delete: RESTRICT
+  - collection: subscriptions
+    field: subscription_plan_id
+    related_collection: subscription_plans
+    meta:
+      junction_field: null
+      many_collection: subscriptions
+      many_field: subscription_plan_id
+      one_allowed_collections: null
+      one_collection: subscription_plans
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscriptions
+      column: subscription_plan_id
+      foreign_key_table: subscription_plans
+      foreign_key_column: id
+      constraint_name: subscriptions_subscription_plan_id_fkey
+      on_update: NO ACTION
+      on_delete: RESTRICT
+  - collection: usage_events
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: usage_events
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: usage_events
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: usage_events_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: wallet_auto_reload_pending
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: wallet_auto_reload_pending
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: wallet_auto_reload_pending
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: wallet_auto_reload_pending_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE

--- a/services/cms/snapshots/pre_task-43-flow-step-cost_20260421_082538.yaml
+++ b/services/cms/snapshots/pre_task-43-flow-step-cost_20260421_082538.yaml
@@ -1,0 +1,24253 @@
+version: 1
+directus: 11.16.1
+vendor: postgres
+collections:
+  - collection: account
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: status
+      archive_value: archived
+      collapse: open
+      collection: account
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 2
+      sort_field: null
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: account
+  - collection: account_directus_users
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: account_directus_users
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: import_export
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 3
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: account_directus_users
+  - collection: account_features
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: account_features
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: account_features
+  - collection: ai_conversations
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_conversations
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: chat
+      item_duplication_fields: null
+      note: AI Assistant conversations
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_conversations
+  - collection: ai_model_config
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_model_config
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: tune
+      item_duplication_fields: null
+      note: AI model configuration
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_model_config
+  - collection: ai_prompts
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: status
+      archive_value: archived
+      collapse: open
+      collection: ai_prompts
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: magic_button
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: ai_prompts
+  - collection: ai_token_usage
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_token_usage
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: analytics
+      item_duplication_fields: null
+      note: AI token usage tracking
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_token_usage
+  - collection: ai_wallet
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: account_balance_wallet
+      item_duplication_fields: null
+      note: Pricing v2 — per-account AI wallet (balance/caps/auto-reload)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet
+  - collection: ai_wallet_failed_debits
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet_failed_debits
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: error_outline
+      item_duplication_fields: null
+      note: >-
+        Pricing v2 — captures debit attempts that failed after AI success (for
+        reconciliation)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet_failed_debits
+  - collection: ai_wallet_ledger
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet_ledger
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: receipt_long
+      item_duplication_fields: null
+      note: Pricing v2 — append-only credit/debit ledger
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet_ledger
+  - collection: ai_wallet_topup
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: ai_wallet_topup
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: add_card
+      item_duplication_fields: null
+      note: Pricing v2 — top-up purchases (12-month expiry)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: ai_wallet_topup
+  - collection: api_keys
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: api_keys
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: api_keys
+  - collection: bl_flow_executions
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_flow_executions
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: history
+      item_duplication_fields: null
+      note: Flow execution history
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_flow_executions
+  - collection: bl_flows
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_flows
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: account_tree
+      item_duplication_fields: null
+      note: Flow definitions
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_flows
+  - collection: bl_node_types
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_node_types
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: category
+      item_duplication_fields: null
+      note: Available node types
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_node_types
+  - collection: bl_wasm_modules
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: bl_wasm_modules
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: bl_wasm_modules
+  - collection: calculator_calls
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_calls
+      color: null
+      display_template: null
+      group: calculators
+      hidden: true
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 2
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_calls
+  - collection: calculator_configs
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_configs
+      color: null
+      display_template: null
+      group: calculators
+      hidden: true
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_configs
+  - collection: calculator_layouts
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_layouts
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: dashboard_customize
+      item_duplication_fields: null
+      note: Per-calculator widget layout configs (supports multiple versions)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_layouts
+  - collection: calculator_slots
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_slots
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: widgets
+      item_duplication_fields: null
+      note: Pricing v2 — per-calculator slot accounting (size/AO)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_slots
+  - collection: calculator_templates
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_templates
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_templates
+  - collection: calculator_test_cases
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: calculator_test_cases
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: calculator_test_cases
+  - collection: calculators
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: archived
+      collapse: open
+      collection: calculators
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: sort
+      translations: null
+      unarchive_value: draft
+      versioning: false
+    schema:
+      name: calculators
+  - collection: feature_quotas
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: feature_quotas
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: speed
+      item_duplication_fields: null
+      note: Pricing v2 — materialized per-account quotas (refreshed by job)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: feature_quotas
+  - collection: formula_examples
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: formula_examples
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: formula_examples
+  - collection: formula_tokens
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: formula_tokens
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: key
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: formula_tokens
+  - collection: kb_answer_feedback
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_answer_feedback
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: thumbs_up_down
+      item_duplication_fields: null
+      note: Answer feedback from users
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_answer_feedback
+  - collection: kb_chunks
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_chunks
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: data_array
+      item_duplication_fields: null
+      note: Knowledge base document chunks with embeddings
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_chunks
+  - collection: kb_curated_answers
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_curated_answers
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: star
+      item_duplication_fields: null
+      note: Curated Q&A pairs for knowledge bases
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_curated_answers
+  - collection: kb_documents
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_documents
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: description
+      item_duplication_fields: null
+      note: Knowledge base documents
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_documents
+  - collection: kb_queries
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: kb_queries
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: query_stats
+      item_duplication_fields: null
+      note: KB query tracking for dashboard charts/KPIs
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: kb_queries
+  - collection: knowledge_bases
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: knowledge_bases
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: menu_book
+      item_duplication_fields: null
+      note: Knowledge base containers
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: knowledge_bases
+  - collection: platform_features
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: platform_features
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: platform_features
+  - collection: stripe_webhook_events
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: stripe_webhook_events
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: stripe_webhook_events
+  - collection: subscription_addons
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: subscription_addons
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: add_circle
+      item_duplication_fields: null
+      note: Pricing v2 — recurring add-on packs (slots/AO/storage)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: subscription_addons
+  - collection: subscription_plans
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: subscription_plans
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: local_offer
+      item_duplication_fields: null
+      note: Pricing v2 — modular catalog (one per module/tier)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: subscription_plans
+  - collection: subscriptions
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: subscriptions
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: verified_user
+      item_duplication_fields: null
+      note: Pricing v2 — per-account-per-module subscriptions
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: subscriptions
+  - collection: system_health_snapshots
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: system_health_snapshots
+      color: null
+      display_template: null
+      group: null
+      hidden: true
+      icon: monitor_heart
+      item_duplication_fields: null
+      note: Formula API health snapshots (auto-populated by cron)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: system_health_snapshots
+  - collection: usage_events
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: usage_events
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: event_note
+      item_duplication_fields: null
+      note: Pricing v2 — append-only billable event stream
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: usage_events
+  - collection: wallet_auto_reload_pending
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: wallet_auto_reload_pending
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: autorenew
+      item_duplication_fields: null
+      note: >-
+        Pricing v2 — auto-reload durable queue (ai-api enqueues on low balance;
+        CMS Stripe consumer processes)
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: wallet_auto_reload_pending
+  - collection: widget_components
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: widget_components
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: widgets
+      item_duplication_fields: null
+      note: Component registry for calculator widgets
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: widget_components
+  - collection: widget_templates
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: widget_templates
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: view_quilt
+      item_duplication_fields: null
+      note: Layout templates for calculator widgets
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: widget_templates
+  - collection: widget_themes
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: widget_themes
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: palette
+      item_duplication_fields: null
+      note: Theme presets for calculator widgets
+      preview_url: null
+      singleton: false
+      sort: null
+      sort_field: sort
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: widget_themes
+fields:
+  - collection: account
+    field: id
+    type: uuid
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: account
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: status
+    type: string
+    meta:
+      collection: account
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: $t:published
+            value: published
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: $t:archived
+            value: archived
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--primary)
+            text: $t:published
+            value: published
+          - color: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - color: var(--theme--warning)
+            text: $t:archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: account
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: user_created
+    type: uuid
+    meta:
+      collection: account
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: account
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: account
+    field: date_created
+    type: timestamp
+    meta:
+      collection: account
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: account
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: user_updated
+    type: uuid
+    meta:
+      collection: account
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: account
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: account
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: account
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: account
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: calculators
+    type: alias
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: calculators
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: account
+    field: users
+    type: alias
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: users
+      group: null
+      hidden: false
+      interface: list-m2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - m2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: account
+    field: name
+    type: string
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: account
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account
+    field: exempt_from_subscription
+    type: boolean
+    meta:
+      collection: account
+      conditions: null
+      display: null
+      display_options: null
+      field: exempt_from_subscription
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: exempt_from_subscription
+      table: account
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_directus_users
+    field: id
+    type: integer
+    meta:
+      collection: account_directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: account_directus_users
+      data_type: integer
+      default_value: nextval('account_directus_users_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_directus_users
+    field: account_id
+    type: uuid
+    meta:
+      collection: account_directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: account_directus_users
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: account_directus_users
+    field: directus_users_id
+    type: uuid
+    meta:
+      collection: account_directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: directus_users_id
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: directus_users_id
+      table: account_directus_users
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: account_features
+    field: id
+    type: uuid
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: account_features
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_features
+    field: account
+    type: uuid
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: account_features
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: account_features
+    field: feature
+    type: uuid
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: feature
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: feature
+      table: account_features
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: platform_features
+      foreign_key_column: id
+  - collection: account_features
+    field: enabled
+    type: boolean
+    meta:
+      collection: account_features
+      conditions: null
+      display: null
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: enabled
+      table: account_features
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_features
+    field: date_created
+    type: timestamp
+    meta:
+      collection: account_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: account_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: account_features
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: account_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: account_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: account
+    type: uuid
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: related-values
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: ai_conversations
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: total_input_tokens
+    type: integer
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: total_input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: total_input_tokens
+      table: ai_conversations
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: status
+    type: string
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: labels
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Active
+            value: active
+          - text: Archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: ai_conversations
+      data_type: character varying
+      default_value: active
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: messages
+    type: json
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: messages
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: messages
+      table: ai_conversations
+      data_type: json
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: ai_conversations
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: title
+    type: string
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: title
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: title
+      table: ai_conversations
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_conversations
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: id
+    type: uuid
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_conversations
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: model
+    type: string
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: model
+      table: ai_conversations
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: total_output_tokens
+    type: integer
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: raw
+      display_options: null
+      field: total_output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: total_output_tokens
+      table: ai_conversations
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_conversations
+    field: user_created
+    type: uuid
+    meta:
+      collection: ai_conversations
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: ai_conversations
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: enabled
+    type: boolean
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: boolean
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: enabled
+      table: ai_model_config
+      data_type: boolean
+      default_value: true
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: ai_model_config
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: max_output_tokens
+    type: integer
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: max_output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: max_output_tokens
+      table: ai_model_config
+      data_type: integer
+      default_value: 4096
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: id
+    type: uuid
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_model_config
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_model_config
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: task_category
+    type: string
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: task_category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: task_category
+      table: ai_model_config
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: max_input_tokens
+    type: integer
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: max_input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: max_input_tokens
+      table: ai_model_config
+      data_type: integer
+      default_value: 100000
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_model_config
+    field: model
+    type: string
+    meta:
+      collection: ai_model_config
+      conditions: null
+      display: raw
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: model
+      table: ai_model_config
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: id
+    type: uuid
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: id
+      table: ai_prompts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: sort
+    type: integer
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sort
+      table: ai_prompts
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_prompts
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: user_created
+    type: uuid
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: ai_prompts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: ai_prompts
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: ai_prompts
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: user_updated
+    type: uuid
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: ai_prompts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: ai_prompts
+    field: meta_prompts_notice
+    type: alias
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: meta_prompts_notice
+      group: null
+      hidden: false
+      interface: presentation-notice
+      note: null
+      options:
+        icon: info
+        text: $t:mcp_prompts_collection_schema.meta_prompts_notice
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - alias
+        - no-data
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: ai_prompts
+    field: name
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: formatted-value
+      display_options:
+        font: monospace
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        slug: true
+        trim: true
+      readonly: false
+      required: true
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: ai_prompts
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: status
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: $t:published
+            value: published
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: $t:archived
+            value: archived
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--primary)
+            text: $t:published
+            value: published
+          - color: var(--theme--foreground)
+            text: $t:draft
+            value: draft
+          - color: var(--theme--warning)
+            text: $t:archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: ai_prompts
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: description
+    type: text
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: ai_prompts
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: system_prompt
+    type: text
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: null
+      display_options: null
+      field: system_prompt
+      group: null
+      hidden: false
+      interface: input-rich-text-md
+      note: $t:mcp_prompts_collection_schema.system_prompt_note
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: system_prompt
+      table: ai_prompts
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: messages
+    type: json
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: formatted-json-value
+      display_options:
+        format: '{{ role }} • {{ text }}'
+      field: messages
+      group: null
+      hidden: false
+      interface: list
+      note: $t:mcp_prompts_collection_schema.messages_note
+      options:
+        addLabel: New Message
+        fields:
+          - field: role
+            meta:
+              display: labels
+              display_options:
+                choices:
+                  - icon: person
+                    text: $t:mcp_prompts_collection_schema.messages_role_user
+                    value: user
+                  - icon: smart_toy
+                    text: $t:mcp_prompts_collection_schema.messages_role_assistant
+                    value: assistant
+              field: role
+              interface: select-dropdown
+              note: $t:mcp_prompts_collection_schema.messages_role_note
+              options:
+                choices:
+                  - icon: person
+                    text: $t:mcp_prompts_collection_schema.messages_role_user
+                    value: user
+                  - icon: smart_toy
+                    text: $t:mcp_prompts_collection_schema.messages_role_assistant
+                    value: assistant
+              required: true
+              type: string
+              width: full
+            name: role
+            type: string
+          - field: text
+            meta:
+              display: formatted-value
+              display_options:
+                format: true
+              field: text
+              interface: input-rich-text-md
+              note: >-
+                The actual content of the message. You can use {{ curly_braces
+                }} for placeholders that will be replaced with real data.
+              required: true
+              type: text
+              width: full
+            name: text
+            type: text
+        showConfirmDiscard: true
+        template: '{{ role }} • {{ text }}'
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: messages
+      table: ai_prompts
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: user_prompt_template
+    type: text
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: raw
+      display_options: null
+      field: user_prompt_template
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user_prompt_template
+      table: ai_prompts
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: category
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: raw
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: ai_prompts
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_prompts
+    field: icon
+    type: string
+    meta:
+      collection: ai_prompts
+      conditions: null
+      display: raw
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: ai_prompts
+      data_type: character varying
+      default_value: lightbulb
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: ai_token_usage
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: id
+    type: uuid
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_token_usage
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: cost_usd
+    type: decimal
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '$ '
+      field: cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: cost_usd
+      table: ai_token_usage
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 6
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: account
+    type: uuid
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: related-values
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: ai_token_usage
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_token_usage
+    field: output_tokens
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: output_tokens
+      table: ai_token_usage
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: duration_ms
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: duration_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: duration_ms
+      table: ai_token_usage
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: model
+    type: string
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: model
+      table: ai_token_usage
+      data_type: character varying
+      default_value: null
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: input_tokens
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: input_tokens
+      table: ai_token_usage
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: conversation
+    type: uuid
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: related-values
+      display_options: null
+      field: conversation
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: conversation
+      table: ai_token_usage
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: task_category
+    type: string
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: raw
+      display_options: null
+      field: task_category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: task_category
+      table: ai_token_usage
+      data_type: character varying
+      default_value: null
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: response_time_ms
+    type: integer
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: null
+      display_options: null
+      field: response_time_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 999
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response_time_ms
+      table: ai_token_usage
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_token_usage
+    field: tool_calls
+    type: json
+    meta:
+      collection: ai_token_usage
+      conditions: null
+      display: null
+      display_options: null
+      field: tool_calls
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tool_calls
+      table: ai_token_usage
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: id
+    type: uuid
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet
+    field: balance_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: balance_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: balance_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: 0
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 4
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: monthly_cap_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: monthly_cap_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: monthly_cap_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: auto_reload_enabled
+    type: boolean
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: null
+      display_options: null
+      field: auto_reload_enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: auto_reload_enabled
+      table: ai_wallet
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: auto_reload_threshold_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: auto_reload_threshold_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: auto_reload_threshold_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: auto_reload_amount_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: auto_reload_amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: auto_reload_amount_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: last_topup_at
+    type: timestamp
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: datetime
+      display_options: null
+      field: last_topup_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_topup_at
+      table: ai_wallet
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: last_topup_eur
+    type: decimal
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: last_topup_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_topup_eur
+      table: ai_wallet
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: ai_wallet
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_wallet
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: ai_wallet
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: id
+    type: bigInteger
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet_failed_debits
+      data_type: bigint
+      default_value: nextval('ai_wallet_failed_debits_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet_failed_debits
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet_failed_debits
+    field: created_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: datetime
+      display_options: null
+      field: created_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: created_at
+      table: ai_wallet_failed_debits
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: cost_usd
+    type: decimal
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '$ '
+      field: cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cost_usd
+      table: ai_wallet_failed_debits
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: cost_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: cost_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cost_eur
+      table: ai_wallet_failed_debits
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: model
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: model
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: input_tokens
+    type: integer
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: input_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input_tokens
+      table: ai_wallet_failed_debits
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: output_tokens
+    type: integer
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: output_tokens
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: output_tokens
+      table: ai_wallet_failed_debits
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: event_kind
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI Message
+            value: ai.message
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB Ask
+            value: kb.ask
+        showAsDot: true
+      field: event_kind
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: AI Message
+            value: ai.message
+          - color: var(--theme--foreground)
+            text: KB Ask
+            value: kb.ask
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: event_kind
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: module
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: anthropic_request_id
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: anthropic_request_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: anthropic_request_id
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: api_key_id
+    type: uuid
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: api_key_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_key_id
+      table: ai_wallet_failed_debits
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: conversation_id
+    type: uuid
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: conversation_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: conversation_id
+      table: ai_wallet_failed_debits
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: error_reason
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Debit Returned Not OK
+            value: debit_returned_not_ok
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Debit Threw
+            value: debit_threw
+        showAsDot: true
+      field: error_reason
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--danger)
+            text: Debit Returned Not OK
+            value: debit_returned_not_ok
+          - color: var(--theme--danger)
+            text: Debit Threw
+            value: debit_threw
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error_reason
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: error_detail
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: null
+      display_options: null
+      field: error_detail
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Backend-populated error trace; admin diagnostic.
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error_detail
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: reconciled_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: datetime
+      display_options: null
+      field: reconciled_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: reconciled_at
+      table: ai_wallet_failed_debits
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: reconciliation_method
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Manual
+            value: manual
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Auto
+            value: auto
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Waived
+            value: waived
+        showAsDot: true
+      field: reconciliation_method
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Manual
+            value: manual
+          - color: var(--theme--foreground)
+            text: Auto
+            value: auto
+          - color: var(--theme--foreground)
+            text: Waived
+            value: waived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: reconciliation_method
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_failed_debits
+    field: status
+    type: text
+    meta:
+      collection: ai_wallet_failed_debits
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Pending
+            value: pending
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Reconciled
+            value: reconciled
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Waived
+            value: waived
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Pending
+            value: pending
+          - color: var(--theme--success)
+            text: Reconciled
+            value: reconciled
+          - color: var(--theme--foreground)
+            text: Waived
+            value: waived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: ai_wallet_failed_debits
+      data_type: text
+      default_value: pending
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: id
+    type: bigInteger
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet_ledger
+      data_type: bigint
+      default_value: nextval('ai_wallet_ledger_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet_ledger
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet_ledger
+    field: entry_type
+    type: text
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Credit
+            value: credit
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Debit
+            value: debit
+        showAsDot: true
+      field: entry_type
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Credit
+            value: credit
+          - color: var(--theme--danger)
+            text: Debit
+            value: debit
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: entry_type
+      table: ai_wallet_ledger
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: amount_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: amount_eur
+      table: ai_wallet_ledger
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: balance_after_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: balance_after_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: balance_after_eur
+      table: ai_wallet_ledger
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 4
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: source
+    type: text
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Top-up
+            value: topup
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Usage
+            value: usage
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Refund
+            value: refund
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Promo
+            value: promo
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Adjustment
+            value: adjustment
+        showAsDot: true
+      field: source
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--primary)
+            text: Top-up
+            value: topup
+          - color: var(--theme--foreground)
+            text: Usage
+            value: usage
+          - color: var(--theme--foreground)
+            text: Refund
+            value: refund
+          - color: var(--theme--primary)
+            text: Promo
+            value: promo
+          - color: var(--theme--foreground)
+            text: Adjustment
+            value: adjustment
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: source
+      table: ai_wallet_ledger
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: topup_id
+    type: uuid
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: topup_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: topup_id
+      table: ai_wallet_ledger
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: ai_wallet_topup
+      foreign_key_column: id
+  - collection: ai_wallet_ledger
+    field: usage_event_id
+    type: bigInteger
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: usage_event_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: usage_event_id
+      table: ai_wallet_ledger
+      data_type: bigint
+      default_value: null
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: usage_events
+      foreign_key_column: id
+  - collection: ai_wallet_ledger
+    field: metadata
+    type: json
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: null
+      display_options: null
+      field: metadata
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: metadata
+      table: ai_wallet_ledger
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_ledger
+    field: occurred_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_ledger
+      conditions: null
+      display: datetime
+      display_options: null
+      field: occurred_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: occurred_at
+      table: ai_wallet_ledger
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: id
+    type: uuid
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: ai_wallet_topup
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: account_id
+    type: uuid
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: ai_wallet_topup
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: ai_wallet_topup
+    field: amount_eur
+    type: decimal
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: amount_eur
+      table: ai_wallet_topup
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: stripe_payment_intent_id
+    type: text
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_payment_intent_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_payment_intent_id
+      table: ai_wallet_topup
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: stripe_charge_id
+    type: text
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_charge_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_charge_id
+      table: ai_wallet_topup
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: expires_at
+    type: timestamp
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: datetime
+      display_options: null
+      field: expires_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expires_at
+      table: ai_wallet_topup
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: initiated_by_user_id
+    type: uuid
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: initiated_by_user_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: initiated_by_user_id
+      table: ai_wallet_topup
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: ai_wallet_topup
+    field: is_auto_reload
+    type: boolean
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: null
+      display_options: null
+      field: is_auto_reload
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: is_auto_reload
+      table: ai_wallet_topup
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: status
+    type: text
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Pending
+            value: pending
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Completed
+            value: completed
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Refunded
+            value: refunded
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Failed
+            value: failed
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Pending
+            value: pending
+          - color: var(--theme--success)
+            text: Completed
+            value: completed
+          - color: var(--theme--foreground)
+            text: Refunded
+            value: refunded
+          - color: var(--theme--danger)
+            text: Failed
+            value: failed
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: ai_wallet_topup
+      data_type: text
+      default_value: completed
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: date_created
+    type: timestamp
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: ai_wallet_topup
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: ai_wallet_topup
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: ai_wallet_topup
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: ai_wallet_topup
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: account_id
+    type: uuid
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: api_keys
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: api_keys
+    field: allowed_ips
+    type: unknown
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: allowed_ips
+      group: null
+      hidden: false
+      interface: tags
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: allowed_ips
+      table: api_keys
+      data_type: text[]
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: allowed_origins
+    type: unknown
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: allowed_origins
+      group: null
+      hidden: false
+      interface: tags
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: allowed_origins
+      table: api_keys
+      data_type: text[]
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: created_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: created_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: created_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: encrypted_key
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: encrypted_key
+      group: null
+      hidden: true
+      interface: input
+      note: AES-256-GCM encrypted key material; never expose.
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: encrypted_key
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: environment
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Live
+            value: live
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Test
+            value: test
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Dev
+            value: dev
+        showAsDot: true
+      field: environment
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Live
+            value: live
+          - color: var(--theme--warning)
+            text: Test
+            value: test
+          - color: var(--theme--foreground)
+            text: Dev
+            value: dev
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: environment
+      table: api_keys
+      data_type: text
+      default_value: live
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: expires_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: expires_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expires_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: key_hash
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: key_hash
+      group: null
+      hidden: true
+      interface: input
+      note: SHA-256 hash of API key; never expose.
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: key_hash
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: key_prefix
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: key_prefix
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: key_prefix
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: last_used_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: last_used_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_used_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: monthly_quota
+    type: integer
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: monthly_quota
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: monthly_quota
+      table: api_keys
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: name
+    type: text
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: api_keys
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: permissions
+    type: json
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: permissions
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: permissions
+      table: api_keys
+      data_type: jsonb
+      default_value:
+        ai: true
+        calc: true
+        flow: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: rate_limit_rps
+    type: integer
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: rate_limit_rps
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: rate_limit_rps
+      table: api_keys
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: revoked_at
+    type: timestamp
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: revoked_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: revoked_at
+      table: api_keys
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: id
+    type: uuid
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: api_keys
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: ai_spend_cap_monthly_eur
+    type: decimal
+    meta:
+      collection: api_keys
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: ai_spend_cap_monthly_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ai_spend_cap_monthly_eur
+      table: api_keys
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: kb_search_cap_monthly
+    type: integer
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: kb_search_cap_monthly
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: kb_search_cap_monthly
+      table: api_keys
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: api_keys
+    field: module_allowlist
+    type: json
+    meta:
+      collection: api_keys
+      conditions: null
+      display: null
+      display_options: null
+      field: module_allowlist
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 19
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module_allowlist
+      table: api_keys
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: flow_id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: flow_id
+      group: null
+      hidden: false
+      interface: input
+      note: Parent flow
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: flow_id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: account_id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account_id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: bl_flow_executions
+    field: status
+    type: text
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: labels
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Pending
+            value: pending
+          - text: Running
+            value: running
+          - text: Completed
+            value: completed
+          - text: Failed
+            value: failed
+          - text: Timed Out
+            value: timed_out
+      readonly: true
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: bl_flow_executions
+      data_type: text
+      default_value: pending
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: trigger_data
+    type: json
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: trigger_data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trigger_data
+      table: bl_flow_executions
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: context
+    type: json
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: context
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: context
+      table: bl_flow_executions
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: result
+    type: json
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: result
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: result
+      table: bl_flow_executions
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: error
+    type: text
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: error
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error
+      table: bl_flow_executions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: duration_ms
+    type: bigInteger
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: duration_ms
+      group: null
+      hidden: false
+      interface: input
+      note: Execution time in ms
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: duration_ms
+      table: bl_flow_executions
+      data_type: bigint
+      default_value: null
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: nodes_executed
+    type: integer
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: nodes_executed
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: nodes_executed
+      table: bl_flow_executions
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: cost_usd
+    type: float
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: AI/LLM cost
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: cost_usd
+      table: bl_flow_executions
+      data_type: real
+      default_value: 0
+      max_length: null
+      numeric_precision: 24
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: worker_id
+    type: uuid
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: worker_id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: worker_id
+      table: bl_flow_executions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: started_at
+    type: timestamp
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: started_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: started_at
+      table: bl_flow_executions
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flow_executions
+    field: completed_at
+    type: timestamp
+    meta:
+      collection: bl_flow_executions
+      conditions: null
+      display: null
+      display_options: null
+      field: completed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: completed_at
+      table: bl_flow_executions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: id
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: name
+    type: text
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: raw
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: Flow name
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: bl_flows
+      data_type: text
+      default_value: Untitled
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: description
+    type: text
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Flow description
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: bl_flows
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: account_id
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: input
+      note: Owner account
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account_id
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: status
+    type: text
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: labels
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Draft
+            value: draft
+          - text: Active
+            value: active
+          - text: Disabled
+            value: disabled
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: bl_flows
+      data_type: text
+      default_value: draft
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: graph
+    type: json
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: graph
+      group: null
+      hidden: false
+      interface: input-code
+      note: Flow DAG (nodes + edges)
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: graph
+      table: bl_flows
+      data_type: json
+      default_value:
+        edges: []
+        nodes: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: trigger_config
+    type: json
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: trigger_config
+      group: null
+      hidden: false
+      interface: input-code
+      note: Trigger configuration
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trigger_config
+      table: bl_flows
+      data_type: json
+      default_value:
+        type: manual
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: settings
+    type: json
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: settings
+      group: null
+      hidden: false
+      interface: input-code
+      note: Execution settings
+      options:
+        language: JSON
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: settings
+      table: bl_flows
+      data_type: json
+      default_value: {}
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: version
+    type: integer
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: version
+      group: null
+      hidden: false
+      interface: input
+      note: Optimistic locking version
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version
+      table: bl_flows
+      data_type: integer
+      default_value: 1
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: created_by
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: created_by
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: created_by
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: updated_by
+    type: uuid
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: updated_by
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: updated_by
+      table: bl_flows
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: created_at
+    type: timestamp
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: created_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: created_at
+      table: bl_flows
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_flows
+    field: updated_at
+    type: timestamp
+    meta:
+      collection: bl_flows
+      conditions: null
+      display: null
+      display_options: null
+      field: updated_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: updated_at
+      table: bl_flows
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: id
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: e.g. core:http_request
+      options: null
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_node_types
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: name
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: bl_node_types
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: description
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: bl_node_types
+      data_type: text
+      default_value: ''
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: category
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: bl_node_types
+      data_type: text
+      default_value: utility
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: tier
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: labels
+      display_options: null
+      field: tier
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Core
+            value: core
+          - text: Wasm
+            value: wasm
+          - text: External
+            value: external
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: tier
+      table: bl_node_types
+      data_type: text
+      default_value: core
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: inputs
+    type: json
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: inputs
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: inputs
+      table: bl_node_types
+      data_type: json
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: outputs
+    type: json
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: outputs
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: outputs
+      table: bl_node_types
+      data_type: json
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: config_schema
+    type: json
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: config_schema
+      group: null
+      hidden: false
+      interface: input-code
+      note: JSON Schema for node config
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: config_schema
+      table: bl_node_types
+      data_type: json
+      default_value: {}
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: estimated_cost_usd
+    type: float
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: estimated_cost_usd
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: estimated_cost_usd
+      table: bl_node_types
+      data_type: real
+      default_value: 0
+      max_length: null
+      numeric_precision: 24
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: required_role
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: labels
+      display_options: null
+      field: required_role
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Any
+            value: any
+          - text: Admin
+            value: admin
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: required_role
+      table: bl_node_types
+      data_type: text
+      default_value: any
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: wasm_module_id
+    type: uuid
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: wasm_module_id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: wasm_module_id
+      table: bl_node_types
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: external_url
+    type: text
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: external_url
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: external_url
+      table: bl_node_types
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: enabled
+    type: boolean
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: enabled
+      table: bl_node_types
+      data_type: boolean
+      default_value: true
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_node_types
+    field: created_at
+    type: timestamp
+    meta:
+      collection: bl_node_types
+      conditions: null
+      display: null
+      display_options: null
+      field: created_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: created_at
+      table: bl_node_types
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: bl_wasm_modules
+    field: id
+    type: integer
+    meta:
+      collection: bl_wasm_modules
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: numeric
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: bl_wasm_modules
+      data_type: integer
+      default_value: nextval('bl_wasm_modules_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_calls
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: response_time_ms
+    type: integer
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: response_time_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response_time_ms
+      table: calculator_calls
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: error_message
+    type: string
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: error_message
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error_message
+      table: calculator_calls
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: timestamp
+    type: dateTime
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: timestamp
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: timestamp
+      table: calculator_calls
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: cached
+    type: boolean
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: cached
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cached
+      table: calculator_calls
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: error
+    type: boolean
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: error
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: error
+      table: calculator_calls
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_calls
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_calls
+    field: test
+    type: boolean
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: test
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test
+      table: calculator_calls
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_calls
+    field: account
+    type: uuid
+    meta:
+      collection: calculator_calls
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: calculator_calls
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: calculator_configs
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: calculator_configs
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: input
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: input
+      group: null
+      hidden: false
+      interface: input-code
+      note: Input json schema
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: output
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: output
+      group: null
+      hidden: false
+      interface: input-code
+      note: Output json schema
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: output
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_configs
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: sheets
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: sheets
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheets
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: formulas
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formulas
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: test_environment
+    type: boolean
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: test_environment
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options:
+        choices: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test_environment
+      table: calculator_configs
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: description
+    type: text
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: calculator_configs
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: excel_file
+    type: uuid
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: file
+      display_options: null
+      field: excel_file
+      group: null
+      hidden: false
+      interface: file
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - file
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: excel_file
+      table: calculator_configs
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_files
+      foreign_key_column: id
+  - collection: calculator_configs
+    field: file_version
+    type: integer
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: file_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: file_version
+      table: calculator_configs
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: config_version
+    type: integer
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: config_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: config_version
+      table: calculator_configs
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: api_key
+    type: string
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: api_key
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_key
+      table: calculator_configs
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: data
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: data
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: integration
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: integration
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: integration
+      table: calculator_configs
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: mcp
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: mcp
+      group: null
+      hidden: false
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: mcp
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: expressions
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: expressions
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expressions
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: profile
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: profile
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: profile
+      table: calculator_configs
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_configs
+    field: unresolved_functions
+    type: json
+    meta:
+      collection: calculator_configs
+      conditions: null
+      display: null
+      display_options: null
+      field: unresolved_functions
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: unresolved_functions
+      table: calculator_configs
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: Linked calculator
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_layouts
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_layouts
+    field: layout_config
+    type: json
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: layout_config
+      group: null
+      hidden: false
+      interface: input-code
+      note: Full layout config JSON
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: layout_config
+      table: calculator_layouts
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: theme
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: theme
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: Optional theme override
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: theme
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: widget_themes
+      foreign_key_column: id
+  - collection: calculator_layouts
+    field: template
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: template
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: Template used as base
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: template
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: widget_templates
+      foreign_key_column: id
+  - collection: calculator_layouts
+    field: version
+    type: string
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version
+      table: calculator_layouts
+      data_type: character varying
+      default_value: '1.0'
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: status
+    type: string
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: calculator_layouts
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: calculator_layouts
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: calculator_layouts
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user_created
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_layouts
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculator_layouts
+      conditions: null
+      display: null
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: user_updated
+      table: calculator_layouts
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_slots
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: account_id
+    type: uuid
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: calculator_slots
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: calculator_slots
+    field: calculator_config_id
+    type: uuid
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator_config_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator_config_id
+      table: calculator_slots
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculator_configs
+      foreign_key_column: id
+  - collection: calculator_slots
+    field: slots_consumed
+    type: integer
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: slots_consumed
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slots_consumed
+      table: calculator_slots
+      data_type: integer
+      default_value: 1
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: is_always_on
+    type: boolean
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: is_always_on
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: is_always_on
+      table: calculator_slots
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: size_class
+    type: text
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: size_class
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: size_class
+      table: calculator_slots
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: file_version
+    type: integer
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: file_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: file_version
+      table: calculator_slots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: config_version
+    type: integer
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: null
+      display_options: null
+      field: config_version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: config_version
+      table: calculator_slots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: computed_at
+    type: timestamp
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: computed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: computed_at
+      table: calculator_slots
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: calculator_slots
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_slots
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_slots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: calculator_slots
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: sort
+    type: integer
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: calculator_templates
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: name
+    type: string
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: calculator_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: description
+    type: text
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: calculator_templates
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: icon
+    type: string
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: select-icon
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: calculator_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: sheets
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: sheets
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheets
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: formulas
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formulas
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: input
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: input
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: output
+    type: json
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: output
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: output
+      table: calculator_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: featured
+    type: boolean
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: featured
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: featured
+      table: calculator_templates
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_templates
+    field: industry
+    type: string
+    meta:
+      collection: calculator_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: industry
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: industry
+      table: calculator_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: id
+    type: uuid
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: calculator_test_cases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: calculator_test_cases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_test_cases
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: calculator_test_cases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: calculator_test_cases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculator_test_cases
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: calculator_test_cases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: input
+    type: json
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: input
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: input
+      table: calculator_test_cases
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: calculator
+    type: string
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: calculator
+      table: calculator_test_cases
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: calculators
+      foreign_key_column: id
+  - collection: calculator_test_cases
+    field: name
+    type: string
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: calculator_test_cases
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: sort
+    type: integer
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: calculator_test_cases
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: expected_outputs
+    type: json
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: expected_outputs
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: expected_outputs
+      table: calculator_test_cases
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculator_test_cases
+    field: tolerance
+    type: float
+    meta:
+      collection: calculator_test_cases
+      conditions: null
+      display: null
+      display_options: null
+      field: tolerance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tolerance
+      table: calculator_test_cases
+      data_type: real
+      default_value: null
+      max_length: null
+      numeric_precision: 24
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: id
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        slug: true
+        trim: true
+      readonly: true
+      required: true
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: id
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: sort
+    type: integer
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: calculators
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: user_created
+    type: uuid
+    meta:
+      collection: calculators
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: calculators
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculators
+    field: date_created
+    type: timestamp
+    meta:
+      collection: calculators
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: calculators
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: user_updated
+    type: uuid
+    meta:
+      collection: calculators
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: calculators
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: calculators
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: calculators
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: calculators
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: configs
+    type: alias
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: configs
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: calculators
+    field: account
+    type: uuid
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: calculators
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: calculators
+    field: name
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: description
+    type: text
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: calculators
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: test_cases
+    type: alias
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: test_cases
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: calculators
+    field: calculator_calls
+    type: alias
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator_calls
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: calculators
+    field: activated
+    type: boolean
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: activated
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: activated
+      table: calculators
+      data_type: boolean
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: onboarded
+    type: boolean
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: onboarded
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: onboarded
+      table: calculators
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: ai_name
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: ai_name
+      group: null
+      hidden: false
+      interface: input
+      note: >-
+        General AI-facing name. Used by MCP, Skill, and Plugin unless
+        overridden. Defaults to calculator name.
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ai_name
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: test_expires_at
+    type: dateTime
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: test_expires_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test_expires_at
+      table: calculators
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: activation_expires_at
+    type: dateTime
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: activation_expires_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: activation_expires_at
+      table: calculators
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: over_limit
+    type: boolean
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: over_limit
+      group: null
+      hidden: true
+      interface: boolean
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 19
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: over_limit
+      table: calculators
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: icon
+    type: string
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: select-icon
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: icon
+      table: calculators
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: calculators
+    field: test_enabled_at
+    type: dateTime
+    meta:
+      collection: calculators
+      conditions: null
+      display: null
+      display_options: null
+      field: test_enabled_at
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: test_enabled_at
+      table: calculators
+      data_type: timestamp without time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: directus_files
+    field: calculator_config
+    type: alias
+    meta:
+      collection: directus_files
+      conditions: null
+      display: null
+      display_options: null
+      field: calculator_config
+      group: null
+      hidden: false
+      interface: list-o2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - o2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: directus_users
+    field: accounts
+    type: alias
+    meta:
+      collection: directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: accounts
+      group: null
+      hidden: false
+      interface: list-m2m
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - m2m
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+  - collection: directus_users
+    field: active_account
+    type: uuid
+    meta:
+      collection: directus_users
+      conditions: null
+      display: null
+      display_options: null
+      field: active_account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: active_account
+      table: directus_users
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: feature_quotas
+    field: id
+    type: uuid
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: feature_quotas
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: account_id
+    type: uuid
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: feature_quotas
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: feature_quotas
+    field: module
+    type: unknown
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: feature_quotas
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: slot_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: slot_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slot_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: ao_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: ao_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ao_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: request_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: request_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: request_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: storage_mb
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: storage_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: storage_mb
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: embed_tokens_m
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: embed_tokens_m
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embed_tokens_m
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: executions
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: executions
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: executions
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: max_steps
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: max_steps
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: max_steps
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: concurrent_runs
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: concurrent_runs
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: concurrent_runs
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: scheduled_triggers
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: scheduled_triggers
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: scheduled_triggers
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: api_keys_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: api_keys_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_keys_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: users_allowance
+    type: integer
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: users_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: users_allowance
+      table: feature_quotas
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: source_subscription_id
+    type: uuid
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: null
+      display_options: null
+      field: source_subscription_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: source_subscription_id
+      table: feature_quotas
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+  - collection: feature_quotas
+    field: refreshed_at
+    type: timestamp
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: datetime
+      display_options: null
+      field: refreshed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: refreshed_at
+      table: feature_quotas
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: date_created
+    type: timestamp
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 17
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: feature_quotas
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: feature_quotas
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: feature_quotas
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 18
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: feature_quotas
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: id
+    type: uuid
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: formula_examples
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sort
+    type: integer
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sort
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sort
+      table: formula_examples
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: label
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: label
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: label
+      table: formula_examples
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: mode
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: mode
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Single
+            value: single
+          - text: Batch
+            value: batch
+          - text: Sheet
+            value: sheet
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: mode
+      table: formula_examples
+      data_type: character varying
+      default_value: single
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: advanced
+    type: boolean
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: boolean
+      display_options: null
+      field: advanced
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: advanced
+      table: formula_examples
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: formula
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: formula
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formula
+      table: formula_examples
+      data_type: character varying
+      default_value: null
+      max_length: 1000
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: formulas
+    type: json
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: formulas
+      table: formula_examples
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sheet_formulas
+    type: json
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sheet_formulas
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheet_formulas
+      table: formula_examples
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: data
+    type: text
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: data
+      table: formula_examples
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sheet_data
+    type: text
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sheet_data
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sheet_data
+      table: formula_examples
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_examples
+    field: sheet_data_mode
+    type: string
+    meta:
+      collection: formula_examples
+      conditions: null
+      display: raw
+      display_options: null
+      field: sheet_data_mode
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Data
+            value: data
+          - text: Sheets
+            value: sheets
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sheet_data_mode
+      table: formula_examples
+      data_type: character varying
+      default_value: data
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: id
+    type: uuid
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: formula_tokens
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: account
+    type: uuid
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: formula_tokens
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: formula_tokens
+    field: label
+    type: string
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: label
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: label
+      table: formula_tokens
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: token
+    type: text
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: token
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: token
+      table: formula_tokens
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: date_created
+    type: timestamp
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: formula_tokens
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: last_used_at
+    type: timestamp
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: last_used_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_used_at
+      table: formula_tokens
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: revoked
+    type: boolean
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: revoked
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special:
+        - cast-boolean
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: revoked
+      table: formula_tokens
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: formula_tokens
+    field: revoked_at
+    type: timestamp
+    meta:
+      collection: formula_tokens
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: revoked_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: revoked_at
+      table: formula_tokens
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: id
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_answer_feedback
+    field: account
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_answer_feedback
+    field: conversation_id
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: conversation_id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: conversation_id
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: query
+    type: text
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: query
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: query
+      table: kb_answer_feedback
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: answer_hash
+    type: string
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: answer_hash
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: answer_hash
+      table: kb_answer_feedback
+      data_type: character varying
+      default_value: null
+      max_length: 64
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: rating
+    type: string
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: rating
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: rating
+      table: kb_answer_feedback
+      data_type: character varying
+      default_value: null
+      max_length: 10
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: category
+    type: string
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: kb_answer_feedback
+      data_type: character varying
+      default_value: null
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: comment
+    type: text
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: comment
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: comment
+      table: kb_answer_feedback
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: chunks_used
+    type: json
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: chunks_used
+      group: null
+      hidden: true
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: chunks_used
+      table: kb_answer_feedback
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: chunk_scores
+    type: json
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_scores
+      group: null
+      hidden: true
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: chunk_scores
+      table: kb_answer_feedback
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: response_text
+    type: text
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: response_text
+      group: null
+      hidden: true
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response_text
+      table: kb_answer_feedback
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: user_created
+    type: uuid
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: kb_answer_feedback
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_answer_feedback
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_answer_feedback
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_answer_feedback
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: id
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_chunks
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: document
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: document
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: document
+      table: kb_chunks
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+  - collection: kb_chunks
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_chunks
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_chunks
+    field: account_id
+    type: uuid
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account_id
+      table: kb_chunks
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: chunk_index
+    type: integer
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_index
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: chunk_index
+      table: kb_chunks
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: content
+    type: text
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: content
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: content
+      table: kb_chunks
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: embedding
+    type: unknown
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: embedding
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embedding
+      table: kb_chunks
+      data_type: vector
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: metadata
+    type: json
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: metadata
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: metadata
+      table: kb_chunks
+      data_type: jsonb
+      default_value: {}
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: token_count
+    type: integer
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: token_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: token_count
+      table: kb_chunks
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_chunks
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: contextual_content
+    type: text
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: contextual_content
+      group: null
+      hidden: true
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: contextual_content
+      table: kb_chunks
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: search_vector
+    type: unknown
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: search_vector
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: search_vector
+      table: kb_chunks
+      data_type: tsvector
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: language
+    type: string
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: language
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: language
+      table: kb_chunks
+      data_type: character varying
+      default_value: null
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_chunks
+    field: content_hash
+    type: string
+    meta:
+      collection: kb_chunks
+      conditions: null
+      display: null
+      display_options: null
+      field: content_hash
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: content_hash
+      table: kb_chunks
+      data_type: character varying
+      default_value: null
+      max_length: 64
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: id
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_curated_answers
+    field: account
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_curated_answers
+    field: question
+    type: text
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: question
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: question
+      table: kb_curated_answers
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: answer
+    type: text
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: answer
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: answer
+      table: kb_curated_answers
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: keywords
+    type: json
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: keywords
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: keywords
+      table: kb_curated_answers
+      data_type: jsonb
+      default_value: []
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: embedding
+    type: unknown
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: embedding
+      group: null
+      hidden: true
+      interface: null
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embedding
+      table: kb_curated_answers
+      data_type: vector
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: priority
+    type: string
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: priority
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: priority
+      table: kb_curated_answers
+      data_type: character varying
+      default_value: boost
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: source_document
+    type: uuid
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: source_document
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: source_document
+      table: kb_curated_answers
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+  - collection: kb_curated_answers
+    field: status
+    type: string
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: kb_curated_answers
+      data_type: character varying
+      default_value: published
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: usage_count
+    type: integer
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: usage_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: usage_count
+      table: kb_curated_answers
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: last_served
+    type: timestamp
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: last_served
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_served
+      table: kb_curated_answers
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_curated_answers
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: kb_curated_answers
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_curated_answers
+    field: language
+    type: string
+    meta:
+      collection: kb_curated_answers
+      conditions: null
+      display: null
+      display_options: null
+      field: language
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: language
+      table: kb_curated_answers
+      data_type: character varying
+      default_value: eng
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: id
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_documents
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: knowledge_base
+      table: kb_documents
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_documents
+    field: account
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: kb_documents
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_documents
+    field: file
+    type: uuid
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: file
+      group: null
+      hidden: false
+      interface: file
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: file
+      table: kb_documents
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_files
+      foreign_key_column: id
+  - collection: kb_documents
+    field: title
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: title
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: title
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 500
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: file_type
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: file_type
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: file_type
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: file_size
+    type: bigInteger
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: file_size
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: file_size
+      table: kb_documents
+      data_type: bigint
+      default_value: 0
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: chunk_count
+    type: integer
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: chunk_count
+      table: kb_documents
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: version_hash
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: version_hash
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version_hash
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 64
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: indexing_status
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: indexing_status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: indexing_status
+      table: kb_documents
+      data_type: character varying
+      default_value: pending
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: indexing_error
+    type: text
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: indexing_error
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: indexing_error
+      table: kb_documents
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: last_indexed
+    type: timestamp
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: last_indexed
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_indexed
+      table: kb_documents
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_documents
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_documents
+    field: language
+    type: string
+    meta:
+      collection: kb_documents
+      conditions: null
+      display: null
+      display_options: null
+      field: language
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: language
+      table: kb_documents
+      data_type: character varying
+      default_value: null
+      max_length: 20
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: id
+    type: uuid
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: kb_queries
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: knowledge_base
+    type: uuid
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: related-values
+      display_options: null
+      field: knowledge_base
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: FK to knowledge_bases
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: knowledge_base
+      table: kb_queries
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+  - collection: kb_queries
+    field: account
+    type: uuid
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: related-values
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: FK to account
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account
+      table: kb_queries
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: kb_queries
+    field: query
+    type: text
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: null
+      display_options: null
+      field: query
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: Search/ask query text
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: query
+      table: kb_queries
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: type
+    type: string
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: raw
+      display_options: null
+      field: type
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: search or ask
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: type
+      table: kb_queries
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: result_count
+    type: integer
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: null
+      display_options: null
+      field: result_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: result_count
+      table: kb_queries
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: timestamp
+    type: timestamp
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: datetime
+      display_options: null
+      field: timestamp
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: timestamp
+      table: kb_queries
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: kb_queries
+    field: date_created
+    type: timestamp
+    meta:
+      collection: kb_queries
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: kb_queries
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: id
+    type: uuid
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: knowledge_bases
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: account
+    type: uuid
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: account
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: account
+      table: knowledge_bases
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: knowledge_bases
+    field: name
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: knowledge_bases
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: description
+    type: text
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: knowledge_bases
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: icon
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: knowledge_bases
+      data_type: character varying
+      default_value: menu_book
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: document_count
+    type: integer
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: document_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: document_count
+      table: knowledge_bases
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: chunk_count
+    type: integer
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: chunk_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: chunk_count
+      table: knowledge_bases
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: last_indexed
+    type: timestamp
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: last_indexed
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: last_indexed
+      table: knowledge_bases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: embedding_model
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: embedding_model
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: embedding_model
+      table: knowledge_bases
+      data_type: character varying
+      default_value: text-embedding-3-small
+      max_length: 100
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: status
+    type: string
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: knowledge_bases
+      data_type: character varying
+      default_value: active
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: sort
+    type: integer
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: sort
+      table: knowledge_bases
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: date_created
+    type: timestamp
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 12
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: knowledge_bases
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: knowledge_bases
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: knowledge_bases
+      conditions: null
+      display: null
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 13
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: knowledge_bases
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: id
+    type: uuid
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: platform_features
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: key
+    type: string
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: key
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: key
+      table: platform_features
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: name
+    type: string
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: platform_features
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: description
+    type: text
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: platform_features
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: enabled
+    type: boolean
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: enabled
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: enabled
+      table: platform_features
+      data_type: boolean
+      default_value: true
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: category
+    type: string
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: category
+      table: platform_features
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: sort
+    type: integer
+    meta:
+      collection: platform_features
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: platform_features
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: date_created
+    type: timestamp
+    meta:
+      collection: platform_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: platform_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: platform_features
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: platform_features
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: platform_features
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: id
+    type: bigInteger
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: stripe_webhook_events
+      data_type: bigint
+      default_value: nextval('stripe_webhook_events_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: stripe_event_id
+    type: text
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_event_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_event_id
+      table: stripe_webhook_events
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: event_type
+    type: text
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: event_type
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: event_type
+      table: stripe_webhook_events
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: processed_at
+    type: timestamp
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: datetime
+      display_options: null
+      field: processed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: processed_at
+      table: stripe_webhook_events
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: stripe_webhook_events
+    field: payload
+    type: json
+    meta:
+      collection: stripe_webhook_events
+      conditions: null
+      display: null
+      display_options: null
+      field: payload
+      group: null
+      hidden: true
+      interface: input-code
+      note: Raw Stripe webhook payload — sensitive; admin-only.
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: true
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: payload
+      table: stripe_webhook_events
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: id
+    type: uuid
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: subscription_addons
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: account_id
+    type: uuid
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: subscription_addons
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: subscription_addons
+    field: subscription_id
+    type: uuid
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: subscription_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: subscription_id
+      table: subscription_addons
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+  - collection: subscription_addons
+    field: addon_kind
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: addon_kind
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: addon_kind
+      table: subscription_addons
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: quantity
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: quantity
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: quantity
+      table: subscription_addons
+      data_type: integer
+      default_value: 1
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: slot_allowance_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: slot_allowance_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slot_allowance_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: ao_allowance_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: ao_allowance_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ao_allowance_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: storage_mb_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: storage_mb_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: storage_mb_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: request_allowance_delta
+    type: integer
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: request_allowance_delta
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: request_allowance_delta
+      table: subscription_addons
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: stripe_subscription_item_id
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_subscription_item_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_subscription_item_id
+      table: subscription_addons
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: stripe_price_id
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_price_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_price_id
+      table: subscription_addons
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: price_eur_monthly
+    type: decimal
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: price_eur_monthly
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: price_eur_monthly
+      table: subscription_addons
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: currency
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: null
+      display_options: null
+      field: currency
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: currency
+      table: subscription_addons
+      data_type: text
+      default_value: EUR
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: status
+    type: text
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Active
+            value: active
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Expired
+            value: expired
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Active
+            value: active
+          - color: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - color: var(--theme--danger)
+            text: Expired
+            value: expired
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: subscription_addons
+      data_type: text
+      default_value: active
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: current_period_start
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_start
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_start
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: current_period_end
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_end
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_end
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: cancel_at
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: cancel_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cancel_at
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: date_created
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 18
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_addons
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: subscription_addons
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 19
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: subscription_addons
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: kb_limit
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: kb_limit
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: kb_limit
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: kb_storage_mb
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: kb_storage_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 21
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: kb_storage_mb
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: id
+    type: uuid
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: subscription_plans
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: module
+    type: unknown
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: subscription_plans
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: tier
+    type: unknown
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Growth
+            value: growth
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Scale
+            value: scale
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+        showAsDot: true
+      field: tier
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - color: var(--theme--primary)
+            text: Growth
+            value: growth
+          - color: var(--theme--primary)
+            text: Scale
+            value: scale
+          - color: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tier
+      table: subscription_plans
+      data_type: tier_level
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: name
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: status
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Published
+            value: published
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Draft
+            value: draft
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Archived
+            value: archived
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--success)
+            text: Published
+            value: published
+          - color: var(--theme--warning)
+            text: Draft
+            value: draft
+          - color: var(--theme--foreground)
+            text: Archived
+            value: archived
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: subscription_plans
+      data_type: text
+      default_value: draft
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: stripe_product_id
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_product_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_product_id
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: stripe_price_monthly_id
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_price_monthly_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_price_monthly_id
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: stripe_price_annual_id
+    type: text
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_price_annual_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_price_annual_id
+      table: subscription_plans
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: price_eur_monthly
+    type: decimal
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: price_eur_monthly
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: price_eur_monthly
+      table: subscription_plans
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: price_eur_annual
+    type: decimal
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: price_eur_annual
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: price_eur_annual
+      table: subscription_plans
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: currency_variants
+    type: json
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: currency_variants
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: currency_variants
+      table: subscription_plans
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: slot_allowance
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: slot_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: slot_allowance
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: ao_allowance
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: ao_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ao_allowance
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: request_allowance
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: request_allowance
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: request_allowance
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: storage_mb
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: storage_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: storage_mb
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: embed_tokens_m
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: embed_tokens_m
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 16
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: embed_tokens_m
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: executions
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: executions
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 17
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: executions
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: max_steps
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: max_steps
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 18
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: max_steps
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: concurrent_runs
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: concurrent_runs
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 19
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: concurrent_runs
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: scheduled_triggers
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: scheduled_triggers
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 20
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: scheduled_triggers
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: included_api_keys
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: included_api_keys
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 21
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: included_api_keys
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: included_users
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: included_users
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 22
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: included_users
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: trial_days
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: trial_days
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 23
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trial_days
+      table: subscription_plans
+      data_type: integer
+      default_value: 14
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: sort
+    type: integer
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 24
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: subscription_plans
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: date_created
+    type: timestamp
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 25
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: subscription_plans
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscription_plans
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: subscription_plans
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 26
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: subscription_plans
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: id
+    type: uuid
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: subscriptions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: account_id
+    type: uuid
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: subscriptions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: subscriptions
+    field: subscription_plan_id
+    type: uuid
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: subscription_plan_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: subscription_plan_id
+      table: subscriptions
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: subscription_plans
+      foreign_key_column: id
+  - collection: subscriptions
+    field: module
+    type: unknown
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: subscriptions
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: tier
+    type: unknown
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Growth
+            value: growth
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Scale
+            value: scale
+          - background: var(--theme--primary-background)
+            color: var(--theme--primary)
+            foreground: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+        showAsDot: true
+      field: tier
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Starter
+            value: starter
+          - color: var(--theme--primary)
+            text: Growth
+            value: growth
+          - color: var(--theme--primary)
+            text: Scale
+            value: scale
+          - color: var(--theme--primary)
+            text: Enterprise
+            value: enterprise
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: tier
+      table: subscriptions
+      data_type: tier_level
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: status
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Trialing
+            value: trialing
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Active
+            value: active
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Past Due
+            value: past_due
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Expired
+            value: expired
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Trialing
+            value: trialing
+          - color: var(--theme--success)
+            text: Active
+            value: active
+          - color: var(--theme--danger)
+            text: Past Due
+            value: past_due
+          - color: var(--theme--foreground)
+            text: Canceled
+            value: canceled
+          - color: var(--theme--danger)
+            text: Expired
+            value: expired
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: billing_cycle
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Monthly
+            value: monthly
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Annual
+            value: annual
+        showAsDot: true
+      field: billing_cycle
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Monthly
+            value: monthly
+          - color: var(--theme--success)
+            text: Annual
+            value: annual
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: billing_cycle
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: stripe_customer_id
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_customer_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_customer_id
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: stripe_subscription_id
+    type: text
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_subscription_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_subscription_id
+      table: subscriptions
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: current_period_start
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_start
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_start
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: current_period_end
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: current_period_end
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: current_period_end
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: trial_start
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: trial_start
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trial_start
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: trial_end
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: trial_end
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: trial_end
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: cancel_at
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: cancel_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cancel_at
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: grandfather_price_eur
+    type: decimal
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: grandfather_price_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: grandfather_price_eur
+      table: subscriptions
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 2
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: date_created
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 16
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_created
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: subscriptions
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: subscriptions
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 17
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date_updated
+      table: subscriptions
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: queue_pending
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: queue_pending
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: queue_pending
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: heap_used_mb
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: heap_used_mb
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: heap_used_mb
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: response_time_ms
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: response_time_ms
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: response_time_ms
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: worker_count
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: worker_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: worker_count
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: response
+    type: json
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: response
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: response
+      table: system_health_snapshots
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: status
+    type: string
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: system_health_snapshots
+      data_type: character varying
+      default_value: unknown
+      max_length: 50
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: cache_size
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: cache_size
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: cache_size
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: date_created
+    type: timestamp
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: datetime
+      display_options: null
+      field: date_created
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: system_health_snapshots
+      data_type: timestamp with time zone
+      default_value: CURRENT_TIMESTAMP
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: queue_max
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: queue_max
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: queue_max
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: id
+    type: uuid
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: raw
+      display_options: null
+      field: id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: null
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: system_health_snapshots
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: instance_count
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: null
+      display_options: null
+      field: instance_count
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: instance_count
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: system_health_snapshots
+    field: total_calculators
+    type: integer
+    meta:
+      collection: system_health_snapshots
+      conditions: null
+      display: null
+      display_options: null
+      field: total_calculators
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: total_calculators
+      table: system_health_snapshots
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: id
+    type: bigInteger
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: usage_events
+      data_type: bigint
+      default_value: nextval('usage_events_id_seq'::regclass)
+      max_length: null
+      numeric_precision: 64
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: true
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: account_id
+    type: uuid
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: usage_events
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: usage_events
+    field: api_key_id
+    type: uuid
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: api_key_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: api_key_id
+      table: usage_events
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: module
+    type: unknown
+    meta:
+      collection: usage_events
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: KB
+            value: kb
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: AI
+            value: ai
+        showAsDot: true
+      field: module
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--foreground)
+            text: Calculators
+            value: calculators
+          - color: var(--theme--foreground)
+            text: KB
+            value: kb
+          - color: var(--theme--foreground)
+            text: Flows
+            value: flows
+          - color: var(--theme--foreground)
+            text: AI
+            value: ai
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: module
+      table: usage_events
+      data_type: module_kind
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: event_kind
+    type: text
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: event_kind
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: event_kind
+      table: usage_events
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: quantity
+    type: decimal
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: quantity
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: quantity
+      table: usage_events
+      data_type: numeric
+      default_value: 1
+      max_length: null
+      numeric_precision: 20
+      numeric_scale: 6
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: cost_eur
+    type: decimal
+    meta:
+      collection: usage_events
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: cost_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: cost_eur
+      table: usage_events
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 6
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: metadata
+    type: json
+    meta:
+      collection: usage_events
+      conditions: null
+      display: null
+      display_options: null
+      field: metadata
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+        lineNumber: true
+        lineWrapping: true
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: metadata
+      table: usage_events
+      data_type: jsonb
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: occurred_at
+    type: timestamp
+    meta:
+      collection: usage_events
+      conditions: null
+      display: datetime
+      display_options: null
+      field: occurred_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: occurred_at
+      table: usage_events
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: usage_events
+    field: aggregated_at
+    type: timestamp
+    meta:
+      collection: usage_events
+      conditions: null
+      display: datetime
+      display_options: null
+      field: aggregated_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: aggregated_at
+      table: usage_events
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: id
+    type: uuid
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: wallet_auto_reload_pending
+      data_type: uuid
+      default_value: gen_random_uuid()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: account_id
+    type: uuid
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: account_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 2
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: account_id
+      table: wallet_auto_reload_pending
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: account
+      foreign_key_column: id
+  - collection: wallet_auto_reload_pending
+    field: amount_eur
+    type: decimal
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: formatted-value
+      display_options:
+        format: true
+        prefix: '€ '
+      field: amount_eur
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: amount_eur
+      table: wallet_auto_reload_pending
+      data_type: numeric
+      default_value: null
+      max_length: null
+      numeric_precision: 12
+      numeric_scale: 4
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: created_at
+    type: timestamp
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: datetime
+      display_options: null
+      field: created_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: created_at
+      table: wallet_auto_reload_pending
+      data_type: timestamp with time zone
+      default_value: now()
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: status
+    type: text
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: labels
+      display_options:
+        choices:
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Pending
+            value: pending
+          - background: var(--theme--warning-background)
+            color: var(--theme--warning)
+            foreground: var(--theme--warning)
+            text: Processing
+            value: processing
+          - background: var(--theme--success-background)
+            color: var(--theme--success)
+            foreground: var(--theme--success)
+            text: Succeeded
+            value: succeeded
+          - background: var(--theme--danger-background)
+            color: var(--theme--danger)
+            foreground: var(--theme--danger)
+            text: Failed
+            value: failed
+          - background: var(--theme--background-normal)
+            color: var(--theme--foreground)
+            foreground: var(--theme--foreground)
+            text: Cancelled
+            value: cancelled
+        showAsDot: true
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - color: var(--theme--warning)
+            text: Pending
+            value: pending
+          - color: var(--theme--warning)
+            text: Processing
+            value: processing
+          - color: var(--theme--success)
+            text: Succeeded
+            value: succeeded
+          - color: var(--theme--danger)
+            text: Failed
+            value: failed
+          - color: var(--theme--foreground)
+            text: Cancelled
+            value: cancelled
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: status
+      table: wallet_auto_reload_pending
+      data_type: text
+      default_value: pending
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: processed_at
+    type: timestamp
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: datetime
+      display_options: null
+      field: processed_at
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: processed_at
+      table: wallet_auto_reload_pending
+      data_type: timestamp with time zone
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: stripe_payment_intent_id
+    type: text
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: stripe_payment_intent_id
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: stripe_payment_intent_id
+      table: wallet_auto_reload_pending
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: last_error
+    type: text
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: last_error
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: last_error
+      table: wallet_auto_reload_pending
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: wallet_auto_reload_pending
+    field: attempts
+    type: integer
+    meta:
+      collection: wallet_auto_reload_pending
+      conditions: null
+      display: null
+      display_options: null
+      field: attempts
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: attempts
+      table: wallet_auto_reload_pending
+      data_type: integer
+      default_value: 0
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: id
+    type: uuid
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: widget_components
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: slug
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: slug
+      group: null
+      hidden: false
+      interface: input
+      note: Unique identifier (e.g. slider, bar-chart)
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: slug
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: name
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: description
+    type: text
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: widget_components
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: category
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: category
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Input
+            value: input
+          - text: Output
+            value: output
+          - text: Layout
+            value: layout
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: category
+      table: widget_components
+      data_type: character varying
+      default_value: input
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: icon
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: icon
+      group: null
+      hidden: false
+      interface: input
+      note: Material icon name
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: icon
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: renderer_type
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: renderer_type
+      group: null
+      hidden: false
+      interface: input
+      note: Lit custom element tag (e.g. bl-slider)
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: renderer_type
+      table: widget_components
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: default_props
+    type: json
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: default_props
+      group: null
+      hidden: false
+      interface: input-code
+      note: null
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: default_props
+      table: widget_components
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: prop_schema
+    type: json
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: prop_schema
+      group: null
+      hidden: false
+      interface: input-code
+      note: JSON Schema for component props
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 9
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: prop_schema
+      table: widget_components
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: field_types
+    type: json
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: field_types
+      group: null
+      hidden: false
+      interface: input-code
+      note: Which calculator field types this binds to
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 10
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: field_types
+      table: widget_components
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: supports_animation
+    type: boolean
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: supports_animation
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: supports_animation
+      table: widget_components
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: lazy_load
+    type: boolean
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: lazy_load
+      group: null
+      hidden: false
+      interface: boolean
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: lazy_load
+      table: widget_components
+      data_type: boolean
+      default_value: false
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: sort
+    type: integer
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: widget_components
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: status
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 14
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: widget_components
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_components
+    field: version
+    type: string
+    meta:
+      collection: widget_components
+      conditions: null
+      display: null
+      display_options: null
+      field: version
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 15
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: version
+      table: widget_components
+      data_type: character varying
+      default_value: '1.0'
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: id
+    type: uuid
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: widget_templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: name
+    type: string
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: widget_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: slug
+    type: string
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: slug
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: slug
+      table: widget_templates
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: description
+    type: text
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: description
+      group: null
+      hidden: false
+      interface: input-multiline
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: description
+      table: widget_templates
+      data_type: text
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: thumbnail
+    type: uuid
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: thumbnail
+      group: null
+      hidden: false
+      interface: file-image
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special:
+        - file
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: thumbnail
+      table: widget_templates
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: layout_skeleton
+    type: json
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: layout_skeleton
+      group: null
+      hidden: false
+      interface: input-code
+      note: Pre-defined layout tree with empty slots
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: layout_skeleton
+      table: widget_templates
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: status
+    type: string
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: widget_templates
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_templates
+    field: sort
+    type: integer
+    meta:
+      collection: widget_templates
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: widget_templates
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: id
+    type: uuid
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      searchable: true
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: widget_themes
+      data_type: uuid
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: name
+    type: string
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: name
+      table: widget_themes
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: slug
+    type: string
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: slug
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      searchable: true
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: slug
+      table: widget_themes
+      data_type: character varying
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: variables
+    type: json
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: variables
+      group: null
+      hidden: false
+      interface: input-code
+      note: CSS custom property values
+      options:
+        language: json
+      readonly: false
+      required: false
+      searchable: true
+      sort: 4
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: variables
+      table: widget_themes
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: status
+    type: string
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: status
+      group: null
+      hidden: false
+      interface: select-dropdown
+      note: null
+      options:
+        choices:
+          - text: Published
+            value: published
+          - text: Draft
+            value: draft
+      readonly: false
+      required: false
+      searchable: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: status
+      table: widget_themes
+      data_type: character varying
+      default_value: draft
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: widget_themes
+    field: sort
+    type: integer
+    meta:
+      collection: widget_themes
+      conditions: null
+      display: null
+      display_options: null
+      field: sort
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      searchable: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: sort
+      table: widget_themes
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: 32
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_indexed: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+systemFields: []
+relations:
+  - collection: account
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: account
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: account_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: account
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: account
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: account_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: account_directus_users
+    field: directus_users_id
+    related_collection: directus_users
+    meta:
+      junction_field: account_id
+      many_collection: account_directus_users
+      many_field: directus_users_id
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: accounts
+      sort_field: null
+    schema:
+      table: account_directus_users
+      column: directus_users_id
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: account_directus_users_directus_users_id_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: account_directus_users
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: directus_users_id
+      many_collection: account_directus_users
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: users
+      sort_field: null
+    schema:
+      table: account_directus_users
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: account_directus_users_account_id_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: account_features
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: account_features
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account_features
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: account_features_account_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: account_features
+    field: feature
+    related_collection: platform_features
+    meta:
+      junction_field: null
+      many_collection: account_features
+      many_field: feature
+      one_allowed_collections: null
+      one_collection: platform_features
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: account_features
+      column: feature
+      foreign_key_table: platform_features
+      foreign_key_column: id
+      constraint_name: account_features_feature_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: ai_prompts
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: ai_prompts
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_prompts
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: ai_prompts_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: ai_prompts
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: ai_prompts
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_prompts
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: ai_prompts_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: ai_wallet
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_failed_debits
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_failed_debits
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_failed_debits
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_failed_debits_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_ledger
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_ledger
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_ledger
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_ledger_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_ledger
+    field: topup_id
+    related_collection: ai_wallet_topup
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_ledger
+      many_field: topup_id
+      one_allowed_collections: null
+      one_collection: ai_wallet_topup
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_ledger
+      column: topup_id
+      foreign_key_table: ai_wallet_topup
+      foreign_key_column: id
+      constraint_name: ai_wallet_ledger_topup_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: ai_wallet_ledger
+    field: usage_event_id
+    related_collection: usage_events
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_ledger
+      many_field: usage_event_id
+      one_allowed_collections: null
+      one_collection: usage_events
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_ledger
+      column: usage_event_id
+      foreign_key_table: usage_events
+      foreign_key_column: id
+      constraint_name: ai_wallet_ledger_usage_event_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: ai_wallet_topup
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_topup
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_topup
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: ai_wallet_topup_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: ai_wallet_topup
+    field: initiated_by_user_id
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: ai_wallet_topup
+      many_field: initiated_by_user_id
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: ai_wallet_topup
+      column: initiated_by_user_id
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: ai_wallet_topup_initiated_by_user_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: api_keys
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: api_keys
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: api_keys
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: api_keys_account_id_fkey
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_calls
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_calls
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: calculator_calls
+      sort_field: null
+    schema:
+      table: calculator_calls
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_calls_calculator_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_configs
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_configs_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_configs
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_configs_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_configs
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: configs
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_configs_calculator_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_configs
+    field: excel_file
+    related_collection: directus_files
+    meta:
+      junction_field: null
+      many_collection: calculator_configs
+      many_field: excel_file
+      one_allowed_collections: null
+      one_collection: directus_files
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: calculator_config
+      sort_field: null
+    schema:
+      table: calculator_configs
+      column: excel_file
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      constraint_name: calculator_configs_excel_file_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_layouts
+    field: theme
+    related_collection: widget_themes
+    meta:
+      junction_field: null
+      many_collection: calculator_layouts
+      many_field: theme
+      one_allowed_collections: null
+      one_collection: widget_themes
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_layouts
+      column: theme
+      foreign_key_table: widget_themes
+      foreign_key_column: id
+      constraint_name: calculator_layouts_theme_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_layouts
+    field: template
+    related_collection: widget_templates
+    meta:
+      junction_field: null
+      many_collection: calculator_layouts
+      many_field: template
+      one_allowed_collections: null
+      one_collection: widget_templates
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_layouts
+      column: template
+      foreign_key_table: widget_templates
+      foreign_key_column: id
+      constraint_name: calculator_layouts_template_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_layouts
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_layouts
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_layouts
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_layouts_calculator_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_slots
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: calculator_slots
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_slots
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: calculator_slots_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_slots
+    field: calculator_config_id
+    related_collection: calculator_configs
+    meta:
+      junction_field: null
+      many_collection: calculator_slots
+      many_field: calculator_config_id
+      one_allowed_collections: null
+      one_collection: calculator_configs
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_slots
+      column: calculator_config_id
+      foreign_key_table: calculator_configs
+      foreign_key_column: id
+      constraint_name: calculator_slots_calculator_config_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculator_test_cases
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_test_cases
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_test_cases
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_test_cases_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_test_cases
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculator_test_cases
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculator_test_cases
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculator_test_cases_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculator_test_cases
+    field: calculator
+    related_collection: calculators
+    meta:
+      junction_field: null
+      many_collection: calculator_test_cases
+      many_field: calculator
+      one_allowed_collections: null
+      one_collection: calculators
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: test_cases
+      sort_field: null
+    schema:
+      table: calculator_test_cases
+      column: calculator
+      foreign_key_table: calculators
+      foreign_key_column: id
+      constraint_name: calculator_test_cases_calculator_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: calculators
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculators
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculators
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculators_user_created_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculators
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: calculators
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: calculators
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: calculators_user_updated_foreign
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: calculators
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: calculators
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: calculators
+      sort_field: null
+    schema:
+      table: calculators
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: calculators_account_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: directus_users
+    field: active_account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: directus_users
+      many_field: active_account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: directus_users
+      column: active_account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: directus_users_active_account_foreign
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: feature_quotas
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: feature_quotas
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: feature_quotas
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: feature_quotas_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: feature_quotas
+    field: source_subscription_id
+    related_collection: subscriptions
+    meta:
+      junction_field: null
+      many_collection: feature_quotas
+      many_field: source_subscription_id
+      one_allowed_collections: null
+      one_collection: subscriptions
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: feature_quotas
+      column: source_subscription_id
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+      constraint_name: feature_quotas_source_subscription_id_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: formula_tokens
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: formula_tokens
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: formula_tokens
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: formula_tokens_account_foreign
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_answer_feedback
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_answer_feedback
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_answer_feedback
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_answer_feedback_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_answer_feedback
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_answer_feedback
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_answer_feedback
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_answer_feedback_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_chunks
+    field: document
+    related_collection: kb_documents
+    meta:
+      junction_field: null
+      many_collection: kb_chunks
+      many_field: document
+      one_allowed_collections: null
+      one_collection: kb_documents
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_chunks
+      column: document
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+      constraint_name: kb_chunks_document_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_chunks
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_chunks
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_chunks
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_chunks_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_curated_answers
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_curated_answers
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_curated_answers
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_curated_answers_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_curated_answers
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_curated_answers
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_curated_answers
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_curated_answers_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_curated_answers
+    field: source_document
+    related_collection: kb_documents
+    meta:
+      junction_field: null
+      many_collection: kb_curated_answers
+      many_field: source_document
+      one_allowed_collections: null
+      one_collection: kb_documents
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_curated_answers
+      column: source_document
+      foreign_key_table: kb_documents
+      foreign_key_column: id
+      constraint_name: kb_curated_answers_source_document_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_documents
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_documents
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: delete
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_documents
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_documents_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_documents
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_documents
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_documents
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_documents_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_documents
+    field: file
+    related_collection: directus_files
+    meta:
+      junction_field: null
+      many_collection: kb_documents
+      many_field: file
+      one_allowed_collections: null
+      one_collection: directus_files
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_documents
+      column: file
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      constraint_name: kb_documents_file_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: kb_queries
+    field: knowledge_base
+    related_collection: knowledge_bases
+    meta:
+      junction_field: null
+      many_collection: kb_queries
+      many_field: knowledge_base
+      one_allowed_collections: null
+      one_collection: knowledge_bases
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_queries
+      column: knowledge_base
+      foreign_key_table: knowledge_bases
+      foreign_key_column: id
+      constraint_name: kb_queries_knowledge_base_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: kb_queries
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: kb_queries
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: kb_queries
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: kb_queries_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: knowledge_bases
+    field: account
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: knowledge_bases
+      many_field: account
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: knowledge_bases
+      column: account
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: knowledge_bases_account_fkey
+      on_update: NO ACTION
+      on_delete: SET NULL
+  - collection: subscription_addons
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: subscription_addons
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscription_addons
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: subscription_addons_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: subscription_addons
+    field: subscription_id
+    related_collection: subscriptions
+    meta:
+      junction_field: null
+      many_collection: subscription_addons
+      many_field: subscription_id
+      one_allowed_collections: null
+      one_collection: subscriptions
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscription_addons
+      column: subscription_id
+      foreign_key_table: subscriptions
+      foreign_key_column: id
+      constraint_name: subscription_addons_subscription_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: subscriptions
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: subscriptions
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscriptions
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: subscriptions_account_id_fkey
+      on_update: NO ACTION
+      on_delete: RESTRICT
+  - collection: subscriptions
+    field: subscription_plan_id
+    related_collection: subscription_plans
+    meta:
+      junction_field: null
+      many_collection: subscriptions
+      many_field: subscription_plan_id
+      one_allowed_collections: null
+      one_collection: subscription_plans
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: subscriptions
+      column: subscription_plan_id
+      foreign_key_table: subscription_plans
+      foreign_key_column: id
+      constraint_name: subscriptions_subscription_plan_id_fkey
+      on_update: NO ACTION
+      on_delete: RESTRICT
+  - collection: usage_events
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: usage_events
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: usage_events
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: usage_events_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE
+  - collection: wallet_auto_reload_pending
+    field: account_id
+    related_collection: account
+    meta:
+      junction_field: null
+      many_collection: wallet_auto_reload_pending
+      many_field: account_id
+      one_allowed_collections: null
+      one_collection: account
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: wallet_auto_reload_pending
+      column: account_id
+      foreign_key_table: account
+      foreign_key_column: id
+      constraint_name: wallet_auto_reload_pending_account_id_fkey
+      on_update: NO ACTION
+      on_delete: CASCADE

--- a/services/gateway/main.go
+++ b/services/gateway/main.go
@@ -82,9 +82,17 @@ func main() {
 	// Sublimit checker (task 27)
 	sublimitChecker := service.NewSublimitChecker(dbPool, rdb)
 
-	// Cache invalidation subscriber (task 42) — runs until ctx is cancelled
+	// Cache invalidation subscriber (task 42, task 58.10) — dedicated client
+	// for PubSub so Subscribe() does not hold a connection from the main pool.
+	// go-redis/v9 PubSub internally takes its own connection; a dedicated client
+	// makes this explicit and matches formula-api's quotaSubRedis pattern.
 	if rdb != nil {
-		go service.StartCacheInvalidationSubscriber(ctx, rdb, log.Logger)
+		subOpts, _ := redis.ParseURL(cfg.RedisURL) // already validated above; ignore err
+		subRdb := redis.NewClient(subOpts)
+		go func() {
+			service.StartCacheInvalidationSubscriber(ctx, subRdb, log.Logger)
+			subRdb.Close() //nolint:errcheck
+		}()
 	}
 
 	// Response cache


### PR DESCRIPTION
## Summary
Closes the remaining post-Sprint-B tasks: flow.step pricing, 12-item follow-up bundle, and the 52.3 ghost-field cleanup.

### Task 43 — flow.step flat rate (Option B, pricing decision locked by dm@coignite.dk)
- Migration 037 adds `p_flow_step_cost_eur NUMERIC DEFAULT 0.001` to `aggregate_usage_events()`
- Env-configurable via `FLOW_STEP_COST_EUR` (default €0.001/step)
- **Option X exemption:** TWO classes of steps don't pay the flat rate — (1) `core:llm` billed via AI Wallet, (2) `core:embedding`/`core:vector_search`/`ai:*` KB pipeline = free internal/local compute to encourage KB ingestion
- Pricing doc + cron.ts comment corrected to accurately describe both exemption classes

### Task 58 — 12-item polish bundle
| Item | Outcome |
|---|---|
| 58.1 | DONE — dropped unused `400_missing_metadata` enum |
| 58.2 | DONE — widened green banner to zero-failures-of-any-kind |
| 58.3 | DONE — HTTP 503 (not 500) when webhook secret absent |
| 58.4 | NOP — observatory module has no keep-alive |
| 58.5 | DONE — typed `req`/`res` shapes in webhook-route + webhook-health |
| 58.6 | DONE — rollback-injection test for `provisionWalletTopup` |
| 58.7 | DONE — quota-refresh-failure test for `reconcileSubscriptions` |
| 58.8 | DONE — `computeSubscriptionDates()` extracted; both INSERT + UPDATE share it |
| 58.9 | WONTFIX — 2 channels only, shared-const file overkill; doc updated |
| 58.10 | DONE — dedicated `subRdb` client for gateway subscriber |
| 58.11 | DONE — 6th test asserts publish skipped on ROLLBACK |
| 58.12 | DONE — welcome-wizard tiles have `:aria-pressed`, `role="group"`, 4 new a11y tests |

### Task 52 — closed
User deleted the `account.subscriptions` ghost field via Directus Admin UI; verified clean in `directus_fields`.

## Test plan
- [ ] `cd services/cms/extensions/local/project-extension-usage-consumer && npx vitest run` → 39/39 pass
- [ ] `cd services/cms/extensions/local/project-extension-stripe && npx vitest run` → 150+ pass (was 148)
- [ ] `cd services/cms/extensions/local/project-extension-account && npx vitest run` → 79+ pass (was 75)
- [ ] `cd services/ai-api && npm test` → 313+ pass (was 312)
- [ ] `cd services/gateway && go test ./...` → builds clean, all subscriber tests pass
- [ ] Migration 037 applies cleanly; `_down.sql` reverts to 036-era behavior
- [ ] `SELECT public.aggregate_usage_events(0, 0.001)` returns zero-stats JSONB smoke test
- [ ] Billing Health panel still renders; red banner triggers on forced sig failure

## Commits
8 atomic commits on `dm/task-43-58-followups`.